### PR TITLE
Fail CREATE operation when bad argument is provided

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/api/model/AbstractFile.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/api/model/AbstractFile.java
@@ -8,11 +8,14 @@ import com.oracle.weblogic.imagetool.api.FileResolver;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.logging.Logger;
 
 /**
  * Base class to represent either an installer or a patch file
  */
 public abstract class AbstractFile implements FileResolver {
+
+    private final Logger logger = Logger.getLogger(AbstractFile.class.getName());
 
     protected String key;
     protected CachePolicy cachePolicy;
@@ -24,6 +27,7 @@ public abstract class AbstractFile implements FileResolver {
         this.cachePolicy = cachePolicy;
         this.userId = userId;
         this.password = password;
+        logger.finer("Exiting AbstractFile construction: key=" + key);
     }
 
     protected boolean isFileOnDisk(String filePath) {

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/WLSCommandLine.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/WLSCommandLine.java
@@ -32,7 +32,7 @@ public class WLSCommandLine {
         }
         cmd.setCaseInsensitiveEnumValuesAllowed(ignoreCaseForEnums);
         cmd.setToggleBooleanFlags(false);
-        cmd.setUnmatchedArgumentsAllowed(true);
+        cmd.setUnmatchedArgumentsAllowed(false);
         //cmd.registerConverter(CacheStore.class, x -> new CacheStoreFactory().getCacheStore(x));
 
         List<Object> results = cmd.parseWithHandlers(new CommandLine.RunLast().useOut(out).useAnsi(ansi),

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
@@ -285,7 +285,9 @@ public class CreateImage extends ImageOperation {
         retVal.add(new InstallerFile(useCache, InstallerType.fromValue(installerType.toString()), installerVersion,
                 userId, password));
         retVal.add(new InstallerFile(useCache, InstallerType.JDK, jdkVersion, userId, password));
-        logger.finer("Exiting CreateImage.gatherRequiredInstallers: ");
+        logger.finer("Exiting CreateImage.gatherRequiredInstallers: "
+                + installerType.toString() + ":" + installerVersion + ", "
+                + InstallerType.JDK + ":" + jdkVersion);
         return retVal;
     }
 


### PR DESCRIPTION
It can be confusing for the user when they provide -jdkversion instead of -jdkVersion, and the operation ignores the user's input and takes the default JDK version instead without warnings or errors.