### PR TITLE
skip Java install if base image already has Java installed

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
@@ -13,6 +13,7 @@ public class DockerfileOptions {
     private boolean useWdt = false;
     private boolean applyPatches = false;
     private boolean updateOpatch = false;
+    private boolean skipJavaInstall = false;
     private String username = "oracle";
     private String groupname = "oracle";
     private String javaHome = "/u01/jdk";
@@ -113,6 +114,25 @@ public class DockerfileOptions {
      */
     public void setJavaHome(String value) {
         javaHome = value;
+    }
+
+    /**
+     * Disable the Java installation because Java is already installed.
+     *
+     * @param javaHome the JAVA_HOME from the base image.
+     */
+    public void disableJavaInstall(String javaHome) {
+        this.javaHome = javaHome;
+        skipJavaInstall = true;
+    }
+
+    /**
+     * Referenced by Dockerfile template, for enabling JDK install function.
+     *
+     * @return true if Java should be installed.
+     */
+    public boolean installJava() {
+        return !skipJavaInstall;
     }
 
     /**

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
@@ -237,6 +237,32 @@ public class Utils {
                     "docker command failed with error: " + stringBuilder.toString());
         }
     }
+    //
+    //    public static boolean isJavaInstalled(String dockerImage) throws IOException, InterruptedException {
+    //        boolean result = false;
+    //        List<String> dockerInspectCommand = new ArrayList<>();
+    //        dockerInspectCommand.add("docker");
+    //        dockerInspectCommand.add("inspect");
+    //        dockerInspectCommand.add("--format='{{range .Config.Env}}{{println .}}{{end}}'");
+    //        dockerInspectCommand.add(dockerImage);
+    //        ProcessBuilder processBuilder = new ProcessBuilder(dockerInspectCommand);
+    //        Process process = processBuilder.start();
+    //        BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+    //        String line;
+    //        while ((line = reader.readLine()) != null) {
+    //            System.out.println(line);
+    //            if (line.trim().startsWith("JAVA_HOME")) {
+    //                result = true;
+    //            }
+    //        }
+    //
+    //        int exitVal = process.waitFor();
+    //        if (exitVal != 0) {
+    //            throw new IOException("ERROR:  Unable to inspect image " + dockerImage + ",
+    //            docker returned " + exitVal);
+    //        }
+    //        return result;
+    //    }
 
     private static void writeFromInputToOutputStreams(InputStream inputStream, OutputStream... outputStreams) {
         Thread readerThread = new Thread(() -> {

--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -35,6 +35,7 @@ RUN if [ -z "$(getent group {{groupid}})" ]; then hash groupadd &> /dev/null && 
  && mkdir /u01 \
  && chown {{userid}}:{{groupid}} /u01
 
+{{#installJava}}
 FROM OS_UPDATE as JDK_BUILD
 ARG JAVA_PKG
 
@@ -48,6 +49,7 @@ USER {{userid}}
 RUN tar xzf {{tempDir}}/$JAVA_PKG -C /u01 \
  && mv /u01/jdk* {{java_home}} \
  && rm -rf {{tempDir}}
+{{/installJava}}
 
 FROM OS_UPDATE as WLS_BUILD
 ARG WLS_PKG
@@ -67,7 +69,9 @@ ENV WLS_PKG=${WLS_PKG:-fmw_12.2.1.3.0_wls_Disk1_1of1.zip} \
     PATCHDIR=${PATCHDIR:-patches}
 
 # Install base WLS
+{{#installJava}}
 COPY --from=JDK_BUILD --chown={{userid}}:{{groupid}} {{java_home}} {{java_home}}/
+{{/installJava}}
 COPY --chown={{userid}}:{{groupid}} $WLS_PKG $WLS_RESP {{tempDir}}/
 COPY --chown={{userid}}:{{groupid}} $ORAINST $INV_LOC/
 {{#isOpatchPatchingEnabled}}
@@ -91,7 +95,7 @@ RUN unzip {{tempDir}}/$WLS_PKG -d {{tempDir}} \
  && $ORACLE_HOME/OPatch/opatch napply -silent -oh $ORACLE_HOME -phBaseDir {{tempDir}}/patches \
  && $ORACLE_HOME/OPatch/opatch util cleanup -silent -oh $ORACLE_HOME \
 {{/isPatchingEnabled}}
- && rm -rf {{java_home}} {{tempDir}}
+ && rm -rf {{tempDir}}
 
 {{#isWdtEnabled}}
 FROM OS_UPDATE as WDT_BUILD
@@ -135,7 +139,9 @@ ENV WDT_PKG=${WDT_PKG:-weblogic-deploy.zip} \
 ENV DOMAIN_HOME=${DOMAIN_HOME:-/u01/domains/base_domain} \
     PATH=$PATH:{{java_home}}/bin:${ORACLE_HOME}/oracle_common/common/bin:${ORACLE_HOME}/wlserver/common/bin:${DOMAIN_HOME}/bin:${ORACLE_HOME}
 
+{{#installJava}}
 COPY --from=JDK_BUILD --chown={{userid}}:{{groupid}} {{java_home}} {{java_home}}/
+{{/installJava}}
 COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} $ORACLE_HOME $ORACLE_HOME/
 COPY --chown={{userid}}:{{groupid}} ${WDT_PKG} ${WDT_MODEL} ${WDT_ARCHIVE} ${WDT_VARIABLE} {{tempDir}}/
 
@@ -158,7 +164,7 @@ RUN unzip {{tempDir}}/$WDT_PKG -d $(dirname $WDT_HOME) \
  $VARIABLE_OPT \
  $MODEL_OPT \
  $ARCHIVE_OPT \
- && rm -rf {{java_home}} ${ORACLE_HOME} ${WDT_HOME} {{tempDir}}
+ && rm -rf ${ORACLE_HOME} ${WDT_HOME} {{tempDir}}
 {{/isWdtEnabled}}
 
 FROM {{baseImage}} as FINAL_BUILD
@@ -174,7 +180,9 @@ ARG ADMIN_PORT
 ARG MANAGED_SERVER_PORT
 
 ENV ORACLE_HOME=${ORACLE_HOME} \
+{{#installJava}}
     JAVA_HOME={{java_home}} \
+{{/installJava}}
 {{#isWdtEnabled}}
     ADMIN_NAME=${ADMIN_NAME:-admin-server} \
     ADMIN_HOST=${ADMIN_HOST:-wlsadmin} \
@@ -198,7 +206,9 @@ RUN if [ -z "$(getent group {{groupid}})" ]; then hash groupadd &> /dev/null && 
  && mkdir -p $(dirname {{java_home}}) $(dirname $ORACLE_HOME) $(dirname $DOMAIN_HOME) \
  && chown {{userid}}:{{groupid}} $(dirname {{java_home}}) $(dirname $ORACLE_HOME) $(dirname $DOMAIN_HOME)
 
+{{#installJava}}
 COPY --from=JDK_BUILD --chown={{userid}}:{{groupid}} $JAVA_HOME {{java_home}}/
+{{/installJava}}
 COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} $ORACLE_HOME $ORACLE_HOME/
 {{#isWdtEnabled}}
 COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} $DOMAIN_HOME $DOMAIN_HOME/

--- a/imagetool/src/main/resources/probe-env/test-create-env.sh
+++ b/imagetool/src/main/resources/probe-env/test-create-env.sh
@@ -10,6 +10,10 @@ if [[ -f /etc/os-release ]]; then
   cat /etc/os-release | grep -oE '^VERSION_ID=[\"]?[[:digit:]\.]+[\"]?'
 fi
 
+if [[ ! -z "$JAVA_HOME" ]]; then
+  echo JAVA_HOME="$JAVA_HOME"
+fi
+
 if [[ ! -z "$ORACLE_HOME" ]]; then
   echo ORACLE_HOME="$ORACLE_HOME"
   WLS_TYPE=$(cat $ORACLE_HOME/inventory/registry.xml 2> /dev/null | grep -q 'WebLogic Server for FMW' && printf "fmw")

--- a/imagetool/src/main/resources/probe-env/test-update-env.sh
+++ b/imagetool/src/main/resources/probe-env/test-update-env.sh
@@ -10,6 +10,10 @@ if [[ -f /etc/os-release ]]; then
   cat /etc/os-release | grep -oE '^VERSION_ID=[\"]?[[:digit:]\.]+[\"]?'
 fi
 
+if [[ ! -z "$JAVA_HOME" ]]; then
+  echo JAVA_HOME="$JAVA_HOME"
+fi
+
 if [[ ! -z "$ORACLE_HOME" ]]; then
   echo ORACLE_HOME="$ORACLE_HOME"
   WLS_TYPE=$(cat $ORACLE_HOME/inventory/registry.xml 2> /dev/null | grep -q 'WebLogic Server for FMW' && printf "fmw")


### PR DESCRIPTION
If JAVA_HOME is detected in the environment of the base image, create image will skip the Java installation.  fixes #28