### PR TITLE
Add WDT capability to UPDATE operation

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -23,6 +23,9 @@
       <option name="BINARY_OPERATION_WRAP" value="1" />
       <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
       <option name="WRAP_LONG_LINES" value="true" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ image.
 ## Features
 
 The Image Tool provides three functions within the main script:
-  - [Create Image](site/create-image.md) - The `create` command helps build a WebLogic Docker image from a given base OS
-  image.
-  - [Update Image](site/update-image.md) - The `update` command can be used to apply WebLogic patches to an existing
-  WebLogic Docker image.
-  - [Cache](site/cache.md) - The Image Tool maintains a local file cache for patches and installers.  The `cache`
-  command can be used to manipulate the local file cache.
+  - [Create Image](site/create-image.md) - The `create` command creates a new Docker image and installs the requested 
+  Java and WebLogic software.  Additionally, you can create a WebLogic domain in the image at the same time.
+  - [Update Image](site/update-image.md) - The `update` command creates a new Docker image by applying WebLogic patches 
+  to an existing image.  Additionally, you can create a WebLogic domain if one did not exist previously.
+  - [Cache](site/cache.md) - The Image Tool maintains metadata on the local filesystem for patches and installers.  
+  The `cache` command can be used to manipulate the local metadata.
 
 ## Prerequisites
 
 - Docker client and daemon on the build machine, with minimum Docker version Docker 18.03.1.ce.
-- WebLogic Server and JDK installers from OTN / Oracle e-Delivery.
+- Installers for WebLogic Server and JDK from OTN / Oracle e-Delivery.
 - (For patches) Oracle support credentials.
 - Bash version 4.0 or higher to enable the `<tab>` command complete feature.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Image Tool provides three functions within the main script:
   Java and WebLogic software.  Additionally, you can create a WebLogic domain in the image at the same time.
   - [Update Image](site/update-image.md) - The `update` command creates a new Docker image by applying WebLogic patches 
   to an existing image.  Additionally, you can create a WebLogic domain if one did not exist previously.
-  - [Cache](site/cache.md) - The Image Tool maintains metadata on the local filesystem for patches and installers.  
+  - [Cache](site/cache.md) - The Image Tool maintains metadata on the local file system for patches and installers.  
   The `cache` command can be used to manipulate the local metadata.
 
 ## Prerequisites

--- a/imagetool/src/main/bin/logging.properties
+++ b/imagetool/src/main/bin/logging.properties
@@ -6,8 +6,8 @@
 #
 # Default handler is console only, to enable file logging, switch out the comments below or customize your own
 #
-handlers=java.util.logging.ConsoleHandler
-#handlers=java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+#handlers=java.util.logging.ConsoleHandler
+handlers=java.util.logging.FileHandler, java.util.logging.ConsoleHandler
 
 #
 # Default level for everything is INFO, you can override the level in each logger or raise the default level for all
@@ -15,7 +15,7 @@ handlers=java.util.logging.ConsoleHandler
 # any packages used by the tool.
 #
 
-com.oracle.weblogic.imagetool.level=INFO
+com.oracle.weblogic.imagetool.level=FINEST
 
 #
 # Change log file location and handlers logging level as needed. Note the default level for FileHandler is OFF

--- a/imagetool/src/main/bin/logging.properties
+++ b/imagetool/src/main/bin/logging.properties
@@ -6,8 +6,8 @@
 #
 # Default handler is console only, to enable file logging, switch out the comments below or customize your own
 #
-#handlers=java.util.logging.ConsoleHandler
-handlers=java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+handlers=java.util.logging.ConsoleHandler
+#handlers=java.util.logging.FileHandler, java.util.logging.ConsoleHandler
 
 #
 # Default level for everything is INFO, you can override the level in each logger or raise the default level for all
@@ -15,7 +15,7 @@ handlers=java.util.logging.FileHandler, java.util.logging.ConsoleHandler
 # any packages used by the tool.
 #
 
-com.oracle.weblogic.imagetool.level=FINEST
+com.oracle.weblogic.imagetool.level=INFO
 
 #
 # Change log file location and handlers logging level as needed. Note the default level for FileHandler is OFF

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
@@ -4,7 +4,6 @@
 package com.oracle.weblogic.imagetool.cli.menu;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -13,15 +12,11 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.stream.Collectors;
 
 import com.oracle.weblogic.imagetool.api.model.CommandResponse;
-import com.oracle.weblogic.imagetool.api.model.DomainType;
 import com.oracle.weblogic.imagetool.api.model.InstallerType;
 import com.oracle.weblogic.imagetool.api.model.WLSInstallerType;
 import com.oracle.weblogic.imagetool.impl.InstallerFile;
@@ -29,7 +24,6 @@ import com.oracle.weblogic.imagetool.logging.LoggingFacade;
 import com.oracle.weblogic.imagetool.logging.LoggingFactory;
 import com.oracle.weblogic.imagetool.util.ARUUtil;
 import com.oracle.weblogic.imagetool.util.Constants;
-import com.oracle.weblogic.imagetool.util.HttpUtil;
 import com.oracle.weblogic.imagetool.util.Utils;
 import com.oracle.weblogic.imagetool.util.ValidationResult;
 import picocli.CommandLine.Command;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -107,9 +107,6 @@ public class UpdateImage extends ImageOperation {
                     && (Utils.compareVersions(installerVersion, Constants.DEFAULT_WLS_VERSION) >= 0
                     && Utils.compareVersions(opatchVersion, opatchBugNumberVersion) < 0);
 
-            baseImageProperties.keySet().forEach(x ->
-                    logger.info(x + "=" + baseImageProperties.getProperty(x.toString())));
-
             if (latestPSU || !patches.isEmpty()) {
                 logger.finer("Verifying Patches to WLS ");
                 if (userId == null) {

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
@@ -23,6 +23,7 @@ public class DockerfileOptions {
     private String groupname;
     private String javaHome;
     private String oracleHome;
+    private String wdtHome;
     private String tempDirectory;
     private String baseImageName;
     private ArrayList<String> wdtModelList;
@@ -43,6 +44,7 @@ public class DockerfileOptions {
 
         javaHome = "/u01/jdk";
         oracleHome = "/u01/oracle";
+        wdtHome = "/u01/app/weblogic-deploy";
         tempDirectory = "/tmp/delme";
 
         baseImageName = "oraclelinux:7-slim";
@@ -131,6 +133,18 @@ public class DockerfileOptions {
 
     public String oracle_home() {
         return oracleHome;
+    }
+
+    public String wdt_home() {
+        return wdtHome;
+    }
+
+    public String work_dir() {
+        if (isWdtEnabled()) {
+            return wdt_home();
+        } else {
+            return oracle_home();
+        }
     }
 
     public void setOracleHome(String value) {

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
@@ -30,6 +30,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -455,6 +456,27 @@ public class Utils {
             }
         }
         return retVal;
+    }
+
+    /**
+     * Reads the docker image environment variables into Java Properties.
+     * @param dockerImage the name of the Docker image to read from
+     * @param tmpDir the directory to use on the container to copy a script
+     * @return The key/value pairs representing the ENV of the Docker image
+     * @throws IOException when the Docker command fails
+     * @throws InterruptedException when the Docker command is interrupted
+     */
+    public static Properties getBaseImageProperties(String dockerImage, String tmpDir)
+        throws IOException, InterruptedException {
+
+        List<String> imageEnvCmd = Utils.getDockerRunCmd(tmpDir, dockerImage, "test-env.sh");
+        Properties result = Utils.runDockerCommand(imageEnvCmd);
+
+        if (logger.isLoggable(Level.FINE)) {
+            result.keySet().forEach(x -> logger.fine(
+                "ENV(" + dockerImage + "): " + x + "=" + result.getProperty(x.toString())));
+        }
+        return result;
     }
 
     /**

--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -72,15 +72,15 @@ ENV WLS_PKG=${WLS_PKG:-fmw_12.2.1.3.0_wls_Disk1_1of1.zip} \
 
 # Install base WLS
 {{#installJava}}
-COPY --from=JDK_BUILD --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
+    COPY --from=JDK_BUILD --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
 {{/installJava}}
 COPY --chown={{userid}}:{{groupid}} $WLS_PKG wls.rsp {{{tempDir}}}/
 COPY --chown={{userid}}:{{groupid}} $ORAINST $INV_LOC/
 {{#isOpatchPatchingEnabled}}
-COPY --chown={{userid}}:{{groupid}} p28186730_139400_Generic.zip {{{tmpDir}}}/opatch/
+    COPY --chown={{userid}}:{{groupid}} p28186730_139400_Generic.zip {{{tmpDir}}}/opatch/
 {{/isOpatchPatchingEnabled}}
 {{#isPatchingEnabled}}
-COPY --chown={{userid}}:{{groupid}} $PATCHDIR/* {{{tmpDir}}}/patches/
+    COPY --chown={{userid}}:{{groupid}} $PATCHDIR/* {{{tmpDir}}}/patches/
 {{/isPatchingEnabled}}
 
 USER {{userid}}
@@ -100,24 +100,23 @@ RUN unzip -q {{{tmpDir}}}/$WLS_PKG -d {{{tmpDir}}} \
  && rm -rf {{{tempDir}}}
 
 {{#isWdtEnabled}}
-FROM OS_UPDATE as WDT_BUILD
-LABEL WlsImageToolLayer="intermediate"
+    FROM OS_UPDATE as WDT_BUILD
+    LABEL WlsImageToolLayer="intermediate"
 
-ARG WDT_PKG
-ARG DOMAIN_TYPE
-ARG DOMAIN_PARENT
-ARG DOMAIN_HOME
-ARG WDT_ARCHIVE
-ARG WDT_VARIABLE
-ARG ADMIN_NAME
-ARG ADMIN_HOST
-ARG ADMIN_PORT
-ARG MANAGED_SERVER_PORT
-ARG SCRIPTS_DIR
-ARG WDT_HOME
-ARG RCU_RUN_FLAG
+    ARG WDT_PKG
+    ARG DOMAIN_TYPE
+    ARG DOMAIN_PARENT
+    ARG DOMAIN_HOME
+    ARG WDT_ARCHIVE
+    ARG WDT_VARIABLE
+    ARG ADMIN_NAME
+    ARG ADMIN_HOST
+    ARG ADMIN_PORT
+    ARG MANAGED_SERVER_PORT
+    ARG SCRIPTS_DIR
+    ARG RCU_RUN_FLAG
 
-ENV WDT_PKG=${WDT_PKG:-weblogic-deploy.zip} \
+    ENV WDT_PKG=${WDT_PKG:-weblogic-deploy.zip} \
     ADMIN_NAME=${ADMIN_NAME:-admin-server} \
     ADMIN_HOST=${ADMIN_HOST:-wlsadmin} \
     ADMIN_PORT=${ADMIN_PORT:-7001} \
@@ -131,37 +130,36 @@ ENV WDT_PKG=${WDT_PKG:-weblogic-deploy.zip} \
     WDT_VARIABLE=${WDT_VARIABLE:-} \
     LC_ALL=${DEFAULT_LOCALE:-en_US.UTF-8} \
     PROPERTIES_FILE_DIR={{{oracle_home}}}/properties \
-    WDT_HOME=${WDT_HOME:-/u01/app/weblogic-deploy} \
     SCRIPTS_DIR=${SCRIPTS_DIR:-scripts} \
     RCU_RUN_FLAG=${RCU_RUN_FLAG:-} \
     DOMAIN_HOME=${DOMAIN_HOME:-/u01/domains/base_domain} \
     PATH=$PATH:{{{java_home}}}/bin:{{{oracle_home}}}/oracle_common/common/bin:{{{oracle_home}}}/wlserver/common/bin:${DOMAIN_HOME}/bin:{{{oracle_home}}}
 
-{{#installJava}}
-COPY --from=JDK_BUILD --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
-{{/installJava}}
-COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle_home}}}/
-COPY --chown={{userid}}:{{groupid}} ${WDT_PKG} {{#wdtModels}}{{.}} {{/wdtModels}}${WDT_ARCHIVE} ${WDT_VARIABLE} {{{tmpDir}}}/
+    {{#installJava}}
+        COPY --from=JDK_BUILD --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
+    {{/installJava}}
+    COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle_home}}}/
+    COPY --chown={{userid}}:{{groupid}} ${WDT_PKG} {{#wdtModels}}{{.}} {{/wdtModels}}${WDT_ARCHIVE} ${WDT_VARIABLE} {{{tmpDir}}}/
 
-USER {{userid}}
+    USER {{userid}}
 
-RUN unzip -q {{{tmpDir}}}/$WDT_PKG -d $(dirname $WDT_HOME) \
- && mkdir -p $(dirname ${DOMAIN_HOME}) \
- && mkdir -p ${PROPERTIES_FILE_DIR} \
- && if [ -n "$WDT_ARCHIVE" ]; then ARCHIVE_OPT="-archive_file {{{tmpDir}}}/${WDT_ARCHIVE##*/}"; fi \
- && if [ -n "$WDT_VARIABLE" ]; then VARIABLE_OPT="-variable_file {{{tmpDir}}}/${WDT_VARIABLE##*/}"; fi \
- && if [ -n "${RCU_RUN_FLAG}" ]; then RCU_RUN_OPT="-run_rcu"; fi \
- && cd ${WDT_HOME}/bin \
- && ${WDT_HOME}/bin/createDomain.sh \
- -oracle_home {{{oracle_home}}} \
- -java_home {{{java_home}}} \
- -domain_home ${DOMAIN_HOME} \
- -domain_type ${DOMAIN_TYPE} \
- $RCU_RUN_OPT \
- $VARIABLE_OPT \
- {{{wdtModelFileArgument}}} \
- $ARCHIVE_OPT \
- && rm -rf ${WDT_HOME} {{{tempDir}}}
+    RUN unzip -q {{{tmpDir}}}/$WDT_PKG -d $(dirname {{{wdt_home}}}) \
+    && mkdir -p $(dirname ${DOMAIN_HOME}) \
+    && mkdir -p ${PROPERTIES_FILE_DIR} \
+    && if [ -n "$WDT_ARCHIVE" ]; then ARCHIVE_OPT="-archive_file {{{tmpDir}}}/${WDT_ARCHIVE##*/}"; fi \
+    && if [ -n "$WDT_VARIABLE" ]; then VARIABLE_OPT="-variable_file {{{tmpDir}}}/${WDT_VARIABLE##*/}"; fi \
+    && if [ -n "${RCU_RUN_FLAG}" ]; then RCU_RUN_OPT="-run_rcu"; fi \
+    && cd {{{wdt_home}}}/bin \
+    && {{{wdt_home}}}/bin/createDomain.sh \
+    -oracle_home {{{oracle_home}}} \
+    -java_home {{{java_home}}} \
+    -domain_home ${DOMAIN_HOME} \
+    -domain_type ${DOMAIN_TYPE} \
+    $RCU_RUN_OPT \
+    $VARIABLE_OPT \
+    {{{wdtModelFileArgument}}} \
+    $ARCHIVE_OPT \
+    && rm -rf {{{tempDir}}}
 {{/isWdtEnabled}}
 
 FROM {{baseImage}} as FINAL_BUILD
@@ -200,19 +198,19 @@ RUN if [ -z "$(getent group {{groupid}})" ]; then hash groupadd &> /dev/null && 
  && chown {{userid}}:{{groupid}} $(dirname {{{java_home}}}) $(dirname {{{oracle_home}}}) {{#isWdtEnabled}}$(dirname $DOMAIN_HOME){{/isWdtEnabled}}
 
 {{#installJava}}
-COPY --from=JDK_BUILD --chown={{userid}}:{{groupid}} $JAVA_HOME {{{java_home}}}/
+    COPY --from=JDK_BUILD --chown={{userid}}:{{groupid}} $JAVA_HOME {{{java_home}}}/
 {{/installJava}}
 COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle_home}}}/
 {{#isWdtEnabled}}
-COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} $DOMAIN_HOME $DOMAIN_HOME/
+    COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} $DOMAIN_HOME $DOMAIN_HOME/
 {{/isWdtEnabled}}
 
 USER {{userid}}
-WORKDIR {{{oracle_home}}}
+WORKDIR {{{work_dir}}}
 
 {{#isWdtEnabled}}
-# Expose admin server, managed server port
-EXPOSE $ADMIN_PORT $MANAGED_SERVER_PORT
+    # Expose admin server, managed server port
+    EXPOSE $ADMIN_PORT $MANAGED_SERVER_PORT
 {{/isWdtEnabled}}
 
 #ENTRYPOINT /bin/bash

--- a/imagetool/src/main/resources/docker-files/Update_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Update_Image.mustache
@@ -4,14 +4,114 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 #
 #
+{{#isWdtEnabled}}
+    FROM {{baseImage}} as WDT_BUILD
+    LABEL WlsImageToolLayer="intermediate"
+
+    ARG WDT_PKG
+    ARG DOMAIN_TYPE
+    ARG DOMAIN_PARENT
+    ARG DOMAIN_HOME
+    ARG WDT_ARCHIVE
+    ARG WDT_VARIABLE
+    ARG ADMIN_NAME
+    ARG ADMIN_HOST
+    ARG ADMIN_PORT
+    ARG MANAGED_SERVER_PORT
+    ARG SCRIPTS_DIR
+    ARG WDT_HOME
+    ARG RCU_RUN_FLAG
+
+    ENV WDT_PKG=${WDT_PKG:-weblogic-deploy.zip} \
+    ADMIN_NAME=${ADMIN_NAME:-admin-server} \
+    ADMIN_HOST=${ADMIN_HOST:-wlsadmin} \
+    ADMIN_PORT=${ADMIN_PORT:-7001} \
+    JAVA_HOME={{{java_home}}} \
+    MANAGED_SERVER_NAME=${MANAGED_SERVER_NAME:-} \
+    MANAGED_SERVER_PORT=${MANAGED_SERVER_PORT:-8001} \
+    WLSDEPLOY_PROPERTIES="-Djava.security.egd=file:/dev/./urandom" \
+    DOMAIN_TYPE=${DOMAIN_TYPE:-WLS} \
+    DOMAIN_PARENT=${DOMAIN_PARENT:-/u01/domains} \
+    WDT_ARCHIVE=${WDT_ARCHIVE:-} \
+    WDT_VARIABLE=${WDT_VARIABLE:-} \
+    LC_ALL=${DEFAULT_LOCALE:-en_US.UTF-8} \
+    PROPERTIES_FILE_DIR={{{oracle_home}}}/properties \
+    WDT_HOME=${WDT_HOME:-/u01/app/weblogic-deploy} \
+    SCRIPTS_DIR=${SCRIPTS_DIR:-scripts} \
+    RCU_RUN_FLAG=${RCU_RUN_FLAG:-} \
+    DOMAIN_HOME=${DOMAIN_HOME:-/u01/domains/base_domain} \
+    PATH=$PATH:{{{java_home}}}/bin:{{{oracle_home}}}/oracle_common/common/bin:{{{oracle_home}}}/wlserver/common/bin:${DOMAIN_HOME}/bin:{{{oracle_home}}}
+
+    USER root
+
+    {{#useYum}}
+        RUN yum -y --downloaddir={{{tmpDir}}} install gzip tar unzip \
+        && yum -y --downloaddir={{{tmpDir}}} clean all \
+        && rm -rf {{{tmpDir}}}
+    {{/useYum}}
+    {{#useAptGet}}
+        RUN apt-get -y update \
+        && apt-get -y upgrade \
+        && apt-get -y install gzip tar unzip \
+        && apt-get -y clean all
+    {{/useAptGet}}
+    {{#useApk}}
+        RUN apk update \
+        && apk upgrade \
+        && rm -rf /var/cache/apk/*
+    {{/useApk}}
+    {{#useZypper}}
+        RUN zypper -nq update \
+        && zypper -nq clean \
+        && rm -rf /var/cache/zypp/*
+    {{/useZypper}}
+
+    COPY --chown={{userid}}:{{groupid}} ${WDT_PKG} {{#wdtModels}}{{.}} {{/wdtModels}}${WDT_ARCHIVE} ${WDT_VARIABLE} {{{tmpDir}}}/
+
+    USER {{userid}}
+
+    RUN unzip -q {{{tmpDir}}}/$WDT_PKG -d $(dirname $WDT_HOME) \
+    && mkdir -p $(dirname ${DOMAIN_HOME}) \
+    && mkdir -p ${PROPERTIES_FILE_DIR} \
+    && if [ -n "$WDT_ARCHIVE" ]; then ARCHIVE_OPT="-archive_file {{{tmpDir}}}/${WDT_ARCHIVE##*/}"; fi \
+    && if [ -n "$WDT_VARIABLE" ]; then VARIABLE_OPT="-variable_file {{{tmpDir}}}/${WDT_VARIABLE##*/}"; fi \
+    && if [ -n "${RCU_RUN_FLAG}" ]; then RCU_RUN_OPT="-run_rcu"; fi \
+    && cd ${WDT_HOME}/bin \
+    && ${WDT_HOME}/bin/createDomain.sh \
+    -oracle_home {{{oracle_home}}} \
+    -java_home {{{java_home}}} \
+    -domain_home ${DOMAIN_HOME} \
+    -domain_type ${DOMAIN_TYPE} \
+    $RCU_RUN_OPT \
+    $VARIABLE_OPT \
+    {{{wdtModelFileArgument}}} \
+    $ARCHIVE_OPT \
+    && rm -rf ${WDT_HOME} {{{tempDir}}}
+{{/isWdtEnabled}}
 
 FROM {{baseImage}} as OS_UPDATE
 USER root
 
 ARG PATCHDIR
+{{#isWdtEnabled}}
+ARG DOMAIN_PARENT
+ARG DOMAIN_HOME
+{{/isWdtEnabled}}
 
 ENV PATCHDIR=${PATCHDIR:-patches} \
     OPATCH_NO_FUSER=true
+
+{{#isWdtEnabled}}
+ENV ADMIN_NAME=${ADMIN_NAME:-admin-server} \
+    ADMIN_HOST=${ADMIN_HOST:-wlsadmin} \
+    ADMIN_PORT=${ADMIN_PORT:-7001} \
+    MANAGED_SERVER_NAME=${MANAGED_SERVER_NAME:-} \
+    MANAGED_SERVER_PORT=${MANAGED_SERVER_PORT:-8001} \
+    WLSDEPLOY_PROPERTIES="-Djava.security.egd=file:/dev/./urandom" \
+    DOMAIN_PARENT=${DOMAIN_PARENT:-/u01/domains} \
+    DOMAIN_HOME=${DOMAIN_HOME:-/u01/domains/base_domain}
+    PATH=$PATH:${DOMAIN_HOME}/bin
+{{/isWdtEnabled}}
 
 USER {{userid}}
 
@@ -30,3 +130,7 @@ RUN $ORACLE_HOME/OPatch/opatch napply -silent -oh $ORACLE_HOME -phBaseDir {{{tmp
  && $ORACLE_HOME/OPatch/opatch util cleanup -silent -oh $ORACLE_HOME \
  && rm -rf {{{tmpDir}}}
 {{/isPatchingEnabled}}
+
+{{#isWdtEnabled}}
+    COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} $DOMAIN_HOME $DOMAIN_HOME/
+{{/isWdtEnabled}}

--- a/imagetool/src/main/resources/docker-files/Update_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Update_Image.mustache
@@ -109,7 +109,7 @@ ENV ADMIN_NAME=${ADMIN_NAME:-admin-server} \
     MANAGED_SERVER_PORT=${MANAGED_SERVER_PORT:-8001} \
     WLSDEPLOY_PROPERTIES="-Djava.security.egd=file:/dev/./urandom" \
     DOMAIN_PARENT=${DOMAIN_PARENT:-/u01/domains} \
-    DOMAIN_HOME=${DOMAIN_HOME:-/u01/domains/base_domain}
+    DOMAIN_HOME=${DOMAIN_HOME:-/u01/domains/base_domain} \
     PATH=$PATH:${DOMAIN_HOME}/bin
 {{/isWdtEnabled}}
 

--- a/imagetool/src/main/resources/docker-files/Update_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Update_Image.mustache
@@ -19,7 +19,6 @@
     ARG ADMIN_PORT
     ARG MANAGED_SERVER_PORT
     ARG SCRIPTS_DIR
-    ARG WDT_HOME
     ARG RCU_RUN_FLAG
 
     ENV WDT_PKG=${WDT_PKG:-weblogic-deploy.zip} \
@@ -36,7 +35,6 @@
     WDT_VARIABLE=${WDT_VARIABLE:-} \
     LC_ALL=${DEFAULT_LOCALE:-en_US.UTF-8} \
     PROPERTIES_FILE_DIR={{{oracle_home}}}/properties \
-    WDT_HOME=${WDT_HOME:-/u01/app/weblogic-deploy} \
     SCRIPTS_DIR=${SCRIPTS_DIR:-scripts} \
     RCU_RUN_FLAG=${RCU_RUN_FLAG:-} \
     DOMAIN_HOME=${DOMAIN_HOME:-/u01/domains/base_domain} \
@@ -44,40 +42,21 @@
 
     USER root
 
-    {{#useYum}}
-        RUN yum -y --downloaddir={{{tmpDir}}} install gzip tar unzip \
-        && yum -y --downloaddir={{{tmpDir}}} clean all \
-        && rm -rf {{{tmpDir}}}
-    {{/useYum}}
-    {{#useAptGet}}
-        RUN apt-get -y update \
-        && apt-get -y upgrade \
-        && apt-get -y install gzip tar unzip \
-        && apt-get -y clean all
-    {{/useAptGet}}
-    {{#useApk}}
-        RUN apk update \
-        && apk upgrade \
-        && rm -rf /var/cache/apk/*
-    {{/useApk}}
-    {{#useZypper}}
-        RUN zypper -nq update \
-        && zypper -nq clean \
-        && rm -rf /var/cache/zypp/*
-    {{/useZypper}}
-
     COPY --chown={{userid}}:{{groupid}} ${WDT_PKG} {{#wdtModels}}{{.}} {{/wdtModels}}${WDT_ARCHIVE} ${WDT_VARIABLE} {{{tmpDir}}}/
 
     USER {{userid}}
 
-    RUN unzip -q {{{tmpDir}}}/$WDT_PKG -d $(dirname $WDT_HOME) \
+    RUN mkdir -p $(dirname {{{wdt_home}}}) \
     && mkdir -p $(dirname ${DOMAIN_HOME}) \
     && mkdir -p ${PROPERTIES_FILE_DIR} \
+    && cd $(dirname {{{wdt_home}}}) \
+    && jar xf {{{tmpDir}}}/$WDT_PKG  \
     && if [ -n "$WDT_ARCHIVE" ]; then ARCHIVE_OPT="-archive_file {{{tmpDir}}}/${WDT_ARCHIVE##*/}"; fi \
     && if [ -n "$WDT_VARIABLE" ]; then VARIABLE_OPT="-variable_file {{{tmpDir}}}/${WDT_VARIABLE##*/}"; fi \
     && if [ -n "${RCU_RUN_FLAG}" ]; then RCU_RUN_OPT="-run_rcu"; fi \
-    && cd ${WDT_HOME}/bin \
-    && ${WDT_HOME}/bin/createDomain.sh \
+    && cd {{{wdt_home}}}/bin \
+    && chmod u+x ./*.sh \
+    && ./createDomain.sh \
     -oracle_home {{{oracle_home}}} \
     -java_home {{{java_home}}} \
     -domain_home ${DOMAIN_HOME} \
@@ -86,7 +65,7 @@
     $VARIABLE_OPT \
     {{{wdtModelFileArgument}}} \
     $ARCHIVE_OPT \
-    && rm -rf ${WDT_HOME} {{{tempDir}}}
+    && rm -rf {{{tempDir}}}
 {{/isWdtEnabled}}
 
 FROM {{baseImage}} as OS_UPDATE
@@ -94,8 +73,8 @@ USER root
 
 ARG PATCHDIR
 {{#isWdtEnabled}}
-ARG DOMAIN_PARENT
-ARG DOMAIN_HOME
+    ARG DOMAIN_PARENT
+    ARG DOMAIN_HOME
 {{/isWdtEnabled}}
 
 ENV PATCHDIR=${PATCHDIR:-patches} \
@@ -116,19 +95,19 @@ ENV ADMIN_NAME=${ADMIN_NAME:-admin-server} \
 USER {{userid}}
 
 {{#isOpatchPatchingEnabled}}
-COPY --chown=oracle:oracle p28186730_139400_Generic.zip {{{tmpDir}}}/opatch/
-RUN cd {{{tmpDir}}}/opatch \
- && $JAVA_HOME/bin/jar -xf {{{tmpDir}}}/opatch/p28186730_139400_Generic.zip \
- && $JAVA_HOME/bin/java -jar {{{tmpDir}}}/opatch/6880880/opatch_generic.jar -silent -ignoreSysPrereqs -force -novalidation oracle_home=$ORACLE_HOME \
- && rm -rf {{{tmpDir}}}
+    COPY --chown=oracle:oracle p28186730_139400_Generic.zip {{{tmpDir}}}/opatch/
+    RUN cd {{{tmpDir}}}/opatch \
+    && $JAVA_HOME/bin/jar -xf {{{tmpDir}}}/opatch/p28186730_139400_Generic.zip \
+    && $JAVA_HOME/bin/java -jar {{{tmpDir}}}/opatch/6880880/opatch_generic.jar -silent -ignoreSysPrereqs -force -novalidation oracle_home=$ORACLE_HOME \
+    && rm -rf {{{tmpDir}}}
 {{/isOpatchPatchingEnabled}}
 
 {{#isPatchingEnabled}}
-COPY --chown={{userid}}:{{groupid}} $PATCHDIR/* {{{tempDir}}}/patches/
+    COPY --chown={{userid}}:{{groupid}} $PATCHDIR/* {{{tempDir}}}/patches/
 
-RUN $ORACLE_HOME/OPatch/opatch napply -silent -oh $ORACLE_HOME -phBaseDir {{{tmpDir}}}/patches \
- && $ORACLE_HOME/OPatch/opatch util cleanup -silent -oh $ORACLE_HOME \
- && rm -rf {{{tmpDir}}}
+    RUN $ORACLE_HOME/OPatch/opatch napply -silent -oh $ORACLE_HOME -phBaseDir {{{tmpDir}}}/patches \
+    && $ORACLE_HOME/OPatch/opatch util cleanup -silent -oh $ORACLE_HOME \
+    && rm -rf {{{tmpDir}}}
 {{/isPatchingEnabled}}
 
 {{#isWdtEnabled}}

--- a/site/create-image.md
+++ b/site/create-image.md
@@ -6,42 +6,57 @@ are marked with an asterisk (*). There are a number of optional parameters for t
 ```
 Usage: imagetool create [OPTIONS]
 Build WebLogic docker image
-      --docker=<dockerPath> path to docker executable. Default: docker
+      --chown=<osUserAndGroup>[:<osUserAndGroup>...]
+                    userid:groupid for JDK/Middleware installs and patches. Default:
+                      oracle:oracle.
+      --docker=<dockerPath>
+                    path to docker executable. Default: docker
       --fromImage=<fromImage>
-                            Docker image to use as base image.
+                    Docker image to use as base image.
       --httpProxyUrl=<httpProxyUrl>
-                            proxy for http protocol. Ex: http://myproxy:80 or http:
-                              //user:passwd@myproxy:8080
+                    proxy for http protocol. Ex: http://myproxy:80 or http://user:
+                      passwd@myproxy:8080
       --httpsProxyUrl=<httpsProxyUrl>
-                            proxy for https protocol. Ex: http://myproxy:80 or http:
-                              //user:passwd@myproxy:8080
+                    proxy for https protocol. Ex: http://myproxy:80 or http://user:
+                      passwd@myproxy:8080
+      --installerResponseFile=<installerResponseFile>
+                    path to a response file. Override the default responses for the
+                      Oracle installer
       --jdkVersion=<jdkVersion>
-                            Version of server jdk to install. default: 8u202
-      --latestPSU           Whether to apply patches from latest PSU.
+                    Version of server jdk to install. Default: 8u202
+      --latestPSU   Whether to apply patches from latest PSU.
+      --opatchBugNumber=<opatchBugNumber>
+                    use this opatch patch bug number
       --password=<password for support user id>
-                            Password for support userId
+                    Password for support userId
       --passwordEnv=<environment variable>
-                            environment variable containing the support password
+                    environment variable containing the support password
       --passwordFile=<password file>
-                            path to file containing just the password
+                    path to file containing just the password
       --patches=patchId[,patchId...]
-                            Comma separated patch Ids. Ex: 12345678,87654321
-*     --tag=TAG             Tag for the final build image. Ex: store/oracle/weblogic:
-                              12.2.1.3.0
+                    Comma separated patch Ids. Ex: 12345678,87654321
+*     --tag=TAG     Tag for the final build image. Ex: store/oracle/weblogic:
+                      12.2.1.3.0
       --type=<installerType>
-                            Installer type. default: wls. supported values: wls, fmw
-*     --user=<support email>
-                            Oracle Support email id
+                    Installer type. Default: wls. Supported values: wls, fmw
+      --user=<support email>
+                    Oracle Support email id
       --version=<installerVersion>
-                            Installer version. default: 12.2.1.3.0
+                    Installer version. Default: 12.2.1.3.0
       --wdtArchive=<wdtArchivePath>
-                            path to wdt archive file used by wdt model
+                    path to the WDT archive file used by the WDT model
+      --wdtDomainHome=<wdtDomainHome>
+                    pass to the -domain_home for wdt
+      --wdtDomainType=<wdtDomainType>
+                    WDT Domain Type. Default: WLS. Supported values: WLS, JRF,
+                      RestrictedJRF
       --wdtModel=<wdtModelPath>
-                            path to the wdt model file to create domain with
+                    path to the WDT model file that defines the Domain to create
+      --wdtRunRCU   instruct WDT to run RCU when creating the Domain
       --wdtVariables=<wdtVariablesPath>
-                            path to wdt variables file used by wdt model
+                    path to the WDT variables file for use with the WDT model
       --wdtVersion=<wdtVersion>
-                            wdt version to create the domain
+                    WDT tool version to use
 ```
 
 ## Usage scenarios

--- a/site/update-image.md
+++ b/site/update-image.md
@@ -10,28 +10,48 @@ are marked with an asterisk (*). The password can be provided in one of the thre
 ```
 Usage: imagetool update [OPTIONS]
 Update WebLogic docker image with selected patches
-      --docker=<dockerPath> path to docker executable. Default: docker
+      --chown=<osUserAndGroup>[:<osUserAndGroup>...]
+                    userid:groupid for JDK/Middleware installs and patches. Default:
+                      oracle:oracle.
+      --docker=<dockerPath>
+                    path to docker executable. Default: docker
 *     --fromImage=<fromImage>
-                            Docker image to use as base image.
+                    Docker image to use as base image.
       --httpProxyUrl=<httpProxyUrl>
-                            proxy for http protocol. Ex: http://myproxy:80 or http:
-                              //user:passwd@myproxy:8080
+                    proxy for http protocol. Ex: http://myproxy:80 or http://user:
+                      passwd@myproxy:8080
       --httpsProxyUrl=<httpsProxyUrl>
-                            proxy for https protocol. Ex: http://myproxy:80 or http:
-                              //user:passwd@myproxy:8080
-      --latestPSU           Whether to apply patches from latest PSU.
+                    proxy for https protocol. Ex: http://myproxy:80 or http://user:
+                      passwd@myproxy:8080
+      --latestPSU   Whether to apply patches from latest PSU.
+      --opatchBugNumber=<opatchBugNumber>
+                    use this opatch patch bug number
       --password=<password for support user id>
-                            Password for support userId
+                    Password for support userId
       --passwordEnv=<environment variable>
-                            environment variable containing the support password
+                    environment variable containing the support password
       --passwordFile=<password file>
-                            path to file containing just the password
+                    path to file containing just the password
       --patches=patchId[,patchId...]
-                            Comma separated patch Ids. Ex: p12345678,p87654321
-*     --tag=TAG             Tag for the final build image. Ex: store/oracle/weblogic:
-                              12.2.1.3.0
-*     --user=<support email>
-                            Oracle Support email id
+                    Comma separated patch Ids. Ex: 12345678,87654321
+*     --tag=TAG     Tag for the final build image. Ex: store/oracle/weblogic:
+                      12.2.1.3.0
+      --user=<support email>
+                    Oracle Support email id
+      --wdtArchive=<wdtArchivePath>
+                    path to the WDT archive file used by the WDT model
+      --wdtDomainHome=<wdtDomainHome>
+                    pass to the -domain_home for wdt
+      --wdtDomainType=<wdtDomainType>
+                    WDT Domain Type. Default: WLS. Supported values: WLS, JRF,
+                      RestrictedJRF
+      --wdtModel=<wdtModelPath>
+                    path to the WDT model file that defines the Domain to create
+      --wdtRunRCU   instruct WDT to run RCU when creating the Domain
+      --wdtVariables=<wdtVariablesPath>
+                    path to the WDT variables file for use with the WDT model
+      --wdtVersion=<wdtVersion>
+                    WDT tool version to use
 ```
 
 ## Usage scenarios
@@ -43,10 +63,16 @@ Update WebLogic docker image with selected patches
     imagetool update --fromImage sample:1.0 --tag sample:1.1 --latestPSU --user test@xyz.com --passwordEnv MYVAR
     ```
 
-- Update an image named `sample:1.0` with the selected patches applied.
+- Update an image named `sample:1.0` with the selected patches applied and tag it as `sample:1.1`.
     ```
     imagetool update --fromImage sample:1.0 --tag sample:1.1 --user test@xyz.com --password hello --patches 12345678,87654321
     ```
 
+- Update an image named `wls:12.2.1.3.0` by creating a new WebLogic domain using WDT and tag it as `mydomain:1`.  The WDT 
+installer is accessed from the cache with key wdt_1.1.1.  The model and archive to use are located in a subfolder named `wdt`. 
+    ```
+    imagetool update --fromImage wls:12.2.1.3.0 --tag mydomain:1 --wdtArchive ./wdt/my_domain.zip --wdtModel ./wdt/my_domain.yaml --wdtVersion 1.1.1
+    ```
+    
 ## Copyright
 Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.


### PR DESCRIPTION
Added the ability to create a domain during the UPDATE operation of the Image Tool.  Prior to this enhancement, the update phase could only be used to apply WebLogic patches to an existing image.