### PR TITLE
pass domain type to WDT validate for domain only

### DIFF
--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -158,6 +158,7 @@ RUN unzip -q {{{tmpDir}}}/$WLS_PKG -d {{{tmpDir}}} \
         && chmod u+x ./*.sh \
         && ./validateModel.sh \
         -oracle_home {{{oracle_home}}} \
+        -domain_type {{domainType}} \
         {{{wdtVariableFileArgument}}} {{{wdtModelFileArgument}}} {{{wdtArchiveFileArgument}}}
     {{/modelOnly}}
 

--- a/imagetool/src/main/resources/docker-files/Update_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Update_Image.mustache
@@ -66,6 +66,7 @@
         && chmod u+x ./*.sh \
         && ./validateModel.sh \
         -oracle_home {{{oracle_home}}} \
+        -domain_type {{domainType}} \
         {{{wdtVariableFileArgument}}} {{{wdtModelFileArgument}}} {{{wdtArchiveFileArgument}}}
     {{/modelOnly}}
 


### PR DESCRIPTION
This change is only precautionary.  The validate tool only uses the domain type to locate the correct version of WLST.  In various versions of WLS, the JRF and WLS versions of WLST were in different folders.  Post 12.2.1, WLST is in the same location for both installers.