### PR TITLE
keep tar and gzip tools installed in the final image

### DIFF
--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -11,6 +11,7 @@ USER root
 {{#useYum}}
 RUN yum -y --downloaddir={{{tmpDir}}} install gzip tar unzip \
  && yum -y --downloaddir={{{tmpDir}}} clean all \
+ && rm -rf /var/cache/yum/* \
  && rm -rf {{{tmpDir}}}
 {{/useYum}}
 {{#useAptGet}}
@@ -164,7 +165,7 @@ RUN unzip -q {{{tmpDir}}}/$WLS_PKG -d {{{tmpDir}}} \
 
 {{/isWdtEnabled}}
 
-FROM {{baseImage}} as FINAL_BUILD
+FROM OS_UPDATE as FINAL_BUILD
 
 ARG ADMIN_NAME
 ARG ADMIN_HOST
@@ -186,12 +187,6 @@ ENV ORACLE_HOME={{{oracle_home}}} \
     LC_ALL=${DEFAULT_LOCALE:-en_US.UTF-8} \
     PROPERTIES_FILE_DIR={{{oracle_home}}}/properties \
     PATH=${PATH}:{{{java_home}}}/bin:{{{oracle_home}}}/oracle_common/common/bin:{{{oracle_home}}}/wlserver/common/bin:{{{oracle_home}}}{{#isWdtEnabled}}:${{{domain_home}}}/bin{{/isWdtEnabled}}
-
-## Create user and group
-RUN if [ -z "$(getent group {{groupid}})" ]; then hash groupadd &> /dev/null && groupadd {{groupid}} || exit -1 ; fi \
- && if [ -z "$(getent passwd {{userid}})" ]; then hash useradd &> /dev/null && useradd -g {{groupid}} {{userid}} || exit -1; fi \
- && mkdir /u01 \
- && chown {{userid}}:{{groupid}} /u01
 
 {{#installJava}}
     COPY --from=JDK_BUILD --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/


### PR DESCRIPTION
To keep Image Tool images in line with Java server JRE images, this change will leave the TAR and GZIP tools installed in the final image.  Previously, these tools were installed in an intermediate layer, and then left out of the final image.