### PR TITLE
remove version number from zip installer

### DIFF
--- a/imagetool/pom.xml
+++ b/imagetool/pom.xml
@@ -112,6 +112,7 @@
                             <goal>single</goal>
                         </goals>
                         <configuration>
+                            <finalName>${installer-name}</finalName>
                             <descriptors>
                                 <descriptor>src/assembly/zip.xml</descriptor>
                             </descriptors>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     </scm>
 
     <properties>
+        <installer-name>imagetool</installer-name>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Similar to other projects in this organization, the zip installer should not have a version number in the filename.