### PR TITLE
default to new lax validation for WDT validate with model only

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/ImageOperation.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/ImageOperation.java
@@ -375,6 +375,8 @@ public abstract class ImageOperation implements Callable<CommandResponse> {
                 //Until WDT supports multiple variable files, take single file argument from CLI and convert to list
                 dockerfileOptions.setWdtVariables(Collections.singletonList(wdtVariableFilename));
             }
+
+            dockerfileOptions.setWdtStrictValidation(wdtStrictValidation);
         }
         logger.exiting();
         return retVal;
@@ -571,13 +573,19 @@ public abstract class ImageOperation implements Callable<CommandResponse> {
     )
     private String wdtJavaOptions;
 
-
     @Option(
         names = {"--wdtModelOnly"},
         description = "Install WDT and copy the models to the image, but do not create the domain. "
             + "Default: ${DEFAULT-VALUE}."
     )
     private boolean wdtModelOnly = false;
+
+    @Option(
+        names = {"--wdtStrictValidation"},
+        description = "Use strict validation for the WDT validation method. Only applies when using model only.  "
+            + "Default: ${DEFAULT-VALUE}."
+    )
+    private boolean wdtStrictValidation = false;
 
     @Unmatched
     List<String> unmatchedOptions;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
@@ -43,6 +43,7 @@ public class DockerfileOptions {
     private String wdtJavaOptions;
     private boolean wdtModelOnly;
     private boolean wdtRunRcu;
+    private boolean wdtStrictValidation;
 
     /**
      * Options to be used with the Mustache template.
@@ -70,6 +71,7 @@ public class DockerfileOptions {
         wdtArchiveList = new ArrayList<>();
         wdtVariableList = new ArrayList<>();
         wdtRunRcu = false;
+        wdtStrictValidation = false;
     }
 
     /**
@@ -473,6 +475,16 @@ public class DockerfileOptions {
 
     public DockerfileOptions setRunRcu(boolean value) {
         wdtRunRcu = value;
+        return this;
+    }
+
+
+    public boolean strictValidation() {
+        return wdtStrictValidation;
+    }
+
+    public DockerfileOptions setWdtStrictValidation(boolean value) {
+        wdtStrictValidation = value;
         return this;
     }
 

--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -154,7 +154,7 @@ RUN unzip -q {{{tmpDir}}}/$WLS_PKG -d {{{tmpDir}}} \
     {{/modelOnly}}
     {{#modelOnly}}
         && chmod u+x ./*.sh \
-        && ./validateModel.sh \
+        && ./validateModel.sh {{^strictValidation}}-method lax{{/strictValidation}} \
         -oracle_home {{{oracle_home}}} \
         -domain_type {{domainType}} \
         {{{wdtVariableFileArgument}}} {{{wdtModelFileArgument}}} {{{wdtArchiveFileArgument}}}

--- a/imagetool/src/main/resources/docker-files/Update_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Update_Image.mustache
@@ -63,7 +63,7 @@
         RUN cd {{{wdt_home}}} \
         && cd weblogic-deploy/bin \
         && chmod u+x ./*.sh \
-        && ./validateModel.sh \
+        && ./validateModel.sh {{^strictValidation}}-method lax{{/strictValidation}} \
         -oracle_home {{{oracle_home}}} \
         -domain_type {{domainType}} \
         {{{wdtVariableFileArgument}}} {{{wdtModelFileArgument}}} {{{wdtArchiveFileArgument}}}


### PR DESCRIPTION
Default for modelOnly validation will be method=lax for WDT validate which will skip property and file validation during docker build.  Missing values will show up as info messages and the build will not fail.  To revert to original behavior, run with "--wdtStrictValidation"