### PR TITLE
check for opatch only when we need to apply patch

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -82,25 +82,30 @@ public class UpdateImage extends ImageOperation {
             String opatchVersion = baseImageProperties.getProperty("OPATCH_VERSION");
 
             // We need to find out the actual version number of the opatchBugNumber - what if useCache=always ?
-            String opatchBugNumberVersion;
 
-            if (userId == null && password == null && applyingPatches()) {
-                String opatchFile = cacheStore.getValueFromCache(opatchBugNumber + "_opatch");
-                if (opatchFile != null) {
-                    opatchBugNumberVersion = Utils.getOpatchVersionFromZip(opatchFile);
-                    logger.info("IMG-0008", opatchBugNumber, opatchFile, opatchBugNumberVersion);
+            if (applyingPatches()) {
+
+                String opatchBugNumberVersion;
+
+                if (userId == null && password == null) {
+                    String opatchFile = cacheStore.getValueFromCache(opatchBugNumber + "_opatch");
+                    if (opatchFile != null) {
+                        opatchBugNumberVersion = Utils.getOpatchVersionFromZip(opatchFile);
+                        logger.info("IMG-0008", opatchBugNumber, opatchFile, opatchBugNumberVersion);
+                    } else {
+                        String msg = String.format("OPatch patch number --opatchBugNumber %s cannot be found in cache. "
+                            + "Please download it manually and add it to the cache.", opatchBugNumber);
+                        logger.severe(msg);
+                        throw new IOException(msg);
+                    }
                 } else {
-                    String msg = String.format("OPatch patch number --opatchBugNumber %s cannot be found in cache",
-                            opatchBugNumber);
-                    logger.severe(msg);
-                    throw new IOException(msg);
+                    opatchBugNumberVersion = ARUUtil.getOPatchVersionByBugNumber(opatchBugNumber, userId, password);
                 }
-            } else {
-                opatchBugNumberVersion = ARUUtil.getOPatchVersionByBugNumber(opatchBugNumber, userId, password);
-            }
 
-            if (applyingPatches() && Utils.compareVersions(opatchVersion, opatchBugNumberVersion) < 0) {
-                addOPatch1394ToImage(tmpDir, opatchBugNumber);
+                if (Utils.compareVersions(opatchVersion, opatchBugNumberVersion) < 0) {
+                    addOPatch1394ToImage(tmpDir, opatchBugNumber);
+                }
+
             }
 
             String lsinventoryText = null;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -84,7 +84,7 @@ public class UpdateImage extends ImageOperation {
             // We need to find out the actual version number of the opatchBugNumber - what if useCache=always ?
             String opatchBugNumberVersion;
 
-            if (userId == null && password == null) {
+            if (userId == null && password == null && applyingPatches()) {
                 String opatchFile = cacheStore.getValueFromCache(opatchBugNumber + "_opatch");
                 if (opatchFile != null) {
                     opatchBugNumberVersion = Utils.getOpatchVersionFromZip(opatchFile);

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -82,6 +82,7 @@ public class UpdateImage extends ImageOperation {
             String opatchVersion = baseImageProperties.getProperty("OPATCH_VERSION");
 
             // We need to find out the actual version number of the opatchBugNumber - what if useCache=always ?
+            String lsinventoryText = null;
 
             if (applyingPatches()) {
 
@@ -106,10 +107,6 @@ public class UpdateImage extends ImageOperation {
                     addOPatch1394ToImage(tmpDir, opatchBugNumber);
                 }
 
-            }
-
-            String lsinventoryText = null;
-            if (latestPSU || !patches.isEmpty()) {
                 logger.finer("Verifying Patches to WLS ");
                 if (userId == null) {
                     logger.warning("IMG-0009");


### PR DESCRIPTION
When using update with wdtOnly option without request for any patches, we still check for opatch in the cache.  This change is to avoid the check.