### PR TITLE
Allow temp dir name override

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -134,7 +134,15 @@ public abstract class CommonOptions {
 
     String getTempDirectory() throws IOException {
         if (tempDirectory == null) {
-            Path tmpDir = Files.createTempDirectory(Paths.get(Utils.getBuildWorkingDir()), "wlsimgbuilder_temp");
+            Path tmpDir = null;
+            if (System.getenv("WLSIMG_BLDTMPDIRNAME") != null) {
+                tmpDir = Paths.get(Utils.getBuildWorkingDir(), System.getenv("WLSIMG_BLDTMPDIRNAME"));
+                if (Files.notExists(tmpDir)) {
+                    Files.createDirectory(tmpDir);
+                }
+            } else {
+                tmpDir = Files.createTempDirectory(Paths.get(Utils.getBuildWorkingDir()), "wlsimgbuilder_temp");
+            }
             tempDirectory = tmpDir.toAbsolutePath().toString();
             logger.info("IMG-0003", tempDirectory);
         }


### PR DESCRIPTION
Allow for the temp directory the Image Tool uses to be overridden and specified by the user using an environment variable. This makes it possible to pin the directory used, making it now possible to pin all the directories the Image Tool uses to specific paths.

As this directory is also used as the Docker build context, this also allows for preparing additional files in advance to be included and thus be available during the different additionalBuildCommands stages. This would be a solution for #106 .