### PR TITLE
additional build files support

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/api/model/CachedFile.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/api/model/CachedFile.java
@@ -97,7 +97,7 @@ public class CachedFile {
         logger.entering();
         Path result = null;
         String sourceFile = resolve(cacheStore);
-        logger.info("copying {0} to build context folder.", sourceFile);
+        logger.info("IMG-0043", sourceFile);
         String targetFilename = new File(sourceFile).getName();
         try {
             result = Files.copy(Paths.get(sourceFile), Paths.get(buildContextDir, targetFilename));

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -71,6 +71,17 @@ public abstract class CommonOptions {
             AdditionalBuildCommands additionalBuildCommands = AdditionalBuildCommands.load(additionalBuildCommandsPath);
             dockerfileOptions.setAdditionalBuildCommands(additionalBuildCommands.getContents());
         }
+
+        if (additionalBuildFiles != null) {
+            for (Path additionalFile : additionalBuildFiles) {
+                if (!Files.isRegularFile(additionalFile)) {
+                    throw new FileNotFoundException(Utils.getMessage("IMG-0030", additionalFile));
+                }
+                Path targetFile = Paths.get(getTempDirectory(), additionalFile.getFileName().toString());
+                logger.info("IMG-0043", additionalFile);
+                Utils.copyLocalFile(additionalFile.toString(), targetFile.toString(), false);
+            }
+        }
     }
 
     void runDockerCommand(String dockerfile, List<String> command) throws IOException, InterruptedException {
@@ -242,7 +253,7 @@ public abstract class CommonOptions {
     }
 
     private Path createPatchesTempDirectory() throws IOException {
-        Path tmpPatchesDir = Files.createDirectory(Paths.get(tempDirectory, "patches"));
+        Path tmpPatchesDir = Files.createDirectory(Paths.get(getTempDirectory(), "patches"));
         Files.createFile(Paths.get(tmpPatchesDir.toAbsolutePath().toString(), "dummy.txt"));
         return tmpPatchesDir;
     }
@@ -357,6 +368,12 @@ public abstract class CommonOptions {
         description = "path to a file with additional build commands"
     )
     private Path additionalBuildCommandsPath;
+
+    @Option(
+        names = {"--additionalBuildFiles"},
+        description = "comma separated list of files that should be copied to the build context folder"
+    )
+    private List<Path> additionalBuildFiles;
 
     @Option(
         names = {"--dryRun"},

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -41,3 +41,4 @@ IMG-0039=Using middleware installers ({0}) version {1}
 IMG-0040=When providing custom response files, a response file must be provided for each of the installers {0}.  Found {1}, expected {2}.
 IMG-0041=Using provided installer response file: {0} for {1} install
 IMG-0042={0} was not found or is not a regular file
+IMG-0043=copying {0} to build context folder.

--- a/site/create-image.md
+++ b/site/create-image.md
@@ -8,8 +8,9 @@ Usage: imagetool create [OPTIONS]
 
 | Parameter | Definition | Default |
 | --- | --- | --- |
-|`--additionalBuildCommands`| Path to a file with additional build commands. For more details, see [Additional information](#additional-information). |
-|`--chown` | `userid:groupid` for JDK/Middleware installs and patches.  | `oracle:oracle` |
+| `--additionalBuildCommands` | Path to a file with additional build commands. For more details, see [Additional information](#additional-information). |
+| `--additionalBuildFiles` | Additional files that are required by your `additionalBuildCommands`.  A comma separated list of files that should be copied to the build context. |
+| `--chown` | `userid:groupid` for JDK/Middleware installs and patches.  | `oracle:oracle` |
 | `--docker` | Path to the Docker executable.  |  `docker` |
 | `--dryRun` | Skip Docker build execution and print the Dockerfile to stdout.  |  |
 | `--fromImage` | Docker image to use as a base image when creating a new image. | `oraclelinux:7-slim`  |

--- a/site/rebase-image.md
+++ b/site/rebase-image.md
@@ -11,6 +11,7 @@ Usage: imagetool rebase [OPTIONS]
 | Parameter | Definition | Default |
 | --- | --- | --- |
 | `--additionalBuildCommands` | Path to a file with additional build commands. For more details, see [Additional information](#additional-information). |
+| `--additionalBuildFiles` | Additional files that are required by your `additionalBuildCommands`.  A comma separated list of files that should be copied to the build context. |
 | `--chown` | `userid:groupid` for JDK/Middleware installs and patches.  | `oracle:oracle` |
 | `--docker` | Path to the Docker executable.  |  `docker` |
 | `--dryRun` | Skip Docker build execution and print the Dockerfile to stdout.  |  |

--- a/site/update-image.md
+++ b/site/update-image.md
@@ -23,8 +23,9 @@ Update WebLogic Docker image with selected patches
 ```
 | Parameter | Definition | Default |
 | --- | --- | --- |
-|`--additionalBuildCommands`| Path to a file with additional build commands. For more details, see [Additional information](#additional-information). |
-|`--chown` | `userid:groupid` for JDK/Middleware installs and patches.  | `oracle:oracle` |
+| `--additionalBuildCommands` | Path to a file with additional build commands. For more details, see [Additional information](#additional-information). |
+| `--additionalBuildFiles` | Additional files that are required by your `additionalBuildCommands`.  A comma separated list of files that should be copied to the build context. |
+| `--chown` | `userid:groupid` for JDK/Middleware installs and patches.  | `oracle:oracle` |
 | `--docker` | Path to the Docker executable.  |  `docker` |
 | `--dryRun` | Skip Docker build execution and print the Dockerfile to stdout.  |  |
 | `--fromImage` | Docker image to be updated. The `fromImage` option serves as a starting point for the new image to be created. | `weblogic:12.2.1.3.0`  |


### PR DESCRIPTION
Added ability for user to add custom files to the build context so that additional build commands can utilize those files (like COPY or ADD).  Fixes #106 