### PR TITLE
allow WDT installer name to be other than weblogic-deploy.zip

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
@@ -64,7 +64,7 @@ public class CreateImage extends CommonOptions implements Callable<CommandRespon
 
             List<String> cmdBuilder = getInitialBuildCmd();
             // build wdt args if user passes --wdtModelPath
-            cmdBuilder.addAll(wdtOptions.handleWdtArgsIfRequired(dockerfileOptions, tmpDir, installerType));
+            wdtOptions.handleWdtArgsIfRequired(dockerfileOptions, tmpDir, installerType);
 
             // resolve required patches
             cmdBuilder.addAll(handlePatchFiles(null));

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -137,7 +137,7 @@ public class UpdateImage extends CommonOptions implements Callable<CommandRespon
             List<String> cmdBuilder = getInitialBuildCmd();
 
             // build wdt args if user passes --wdtModelPath
-            cmdBuilder.addAll(wdtOptions.handleWdtArgsIfRequired(dockerfileOptions, tmpDir, installerType));
+            wdtOptions.handleWdtArgsIfRequired(dockerfileOptions, tmpDir, installerType);
             dockerfileOptions.setWdtCommand(wdtOperation);
 
             // resolve required patches

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/WdtOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/WdtOptions.java
@@ -32,18 +32,15 @@ public class WdtOptions {
 
     /**
      * Checks whether the user requested a domain to be created with WDT.
-     * If so, returns the required build args to pass to docker and creates required file links to pass
-     * the model, archive, variables file to build process
+     * If so,  creates required file links to pass the model, archive, variables file to build process.
      *
      * @param tmpDir the tmp directory which is passed to docker as the build context directory
-     * @return list of build args
      * @throws IOException in case of error
      */
-    List<String> handleWdtArgsIfRequired(DockerfileOptions dockerfileOptions, String tmpDir,
+    void handleWdtArgsIfRequired(DockerfileOptions dockerfileOptions, String tmpDir,
                                          FmwInstallerType installerType) throws IOException {
         logger.entering(tmpDir);
 
-        List<String> retVal = new LinkedList<>();
         if (wdtModelPath != null) {
             dockerfileOptions.setWdtEnabled();
             dockerfileOptions.setWdtModelOnly(wdtModelOnly);
@@ -80,10 +77,10 @@ public class WdtOptions {
             dockerfileOptions.setWdtStrictValidation(wdtStrictValidation);
 
             CachedFile wdtInstaller = new CachedFile(InstallerType.WDT, wdtVersion);
-            wdtInstaller.copyFile(cacheStore, tmpDir);
+            Path wdtfile = wdtInstaller.copyFile(cacheStore, tmpDir);
+            dockerfileOptions.setWdtInstallerFilename(wdtfile.getFileName().toString());
         }
         logger.exiting();
-        return retVal;
     }
 
     /**

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
@@ -62,6 +62,7 @@ public class DockerfileOptions {
     private boolean wdtModelOnly;
     private boolean wdtRunRcu;
     private boolean wdtStrictValidation;
+    private String wdtInstallerFilename;
 
     // Additional Build Commands
     private Map<String,List<String>> additionalBuildCommands;
@@ -665,6 +666,15 @@ public class DockerfileOptions {
     public DockerfileOptions setWdtModelOnly(boolean value) {
         wdtModelOnly = value;
         return this;
+    }
+
+    @SuppressWarnings("unused")
+    public String wdtInstaller() {
+        return wdtInstallerFilename;
+    }
+
+    public void setWdtInstallerFilename(String value) {
+        wdtInstallerFilename = value;
     }
 
     public boolean modelOnly() {

--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates.  All rights reserved.
+# Copyright (c) 2019, 2020, Oracle and/or its affiliates.  All rights reserved.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
@@ -124,14 +124,11 @@ RUN {{{oracle_home}}}/OPatch/opatch napply -silent -oh {{{oracle_home}}} -phBase
     FROM WLS_BUILD as WDT_BUILD
     LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
-    ARG WDT_PKG
-
-    ENV WDT_PKG=${WDT_PKG:-weblogic-deploy.zip} \
-        WLSDEPLOY_PROPERTIES="{{wlsdeploy_properties}} -Djava.security.egd=file:/dev/./urandom" \
+    ENV WLSDEPLOY_PROPERTIES="{{wlsdeploy_properties}} -Djava.security.egd=file:/dev/./urandom" \
         LC_ALL=${DEFAULT_LOCALE:-en_US.UTF-8} \
         DOMAIN_HOME={{{domain_home}}}
 
-    COPY --chown={{userid}}:{{groupid}} ${WDT_PKG} {{{tempDir}}}/
+    COPY --chown={{userid}}:{{groupid}} {{{wdtInstaller}}} {{{tempDir}}}/
 
     RUN mkdir -p {{{wdt_home}}} \
     && chown {{userid}}:{{groupid}} {{{wdt_home}}}
@@ -158,7 +155,7 @@ RUN {{{oracle_home}}}/OPatch/opatch napply -silent -oh {{{oracle_home}}} -phBase
         {{{.}}}
     {{/beforeWdtCommand}}
 
-    RUN unzip -q {{{tempDir}}}/$WDT_PKG -d {{{wdt_home}}} \
+    RUN unzip -q {{{tempDir}}}/{{{wdtInstaller}}} -d {{{wdt_home}}} \
         && cd {{{wdt_home}}}/weblogic-deploy/bin \
     {{^modelOnly}}
         && ./createDomain.sh \

--- a/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020 Oracle and/or its affiliates.  All rights reserved.
+# Copyright (c) 2019, 2020, Oracle and/or its affiliates.  All rights reserved.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #

--- a/imagetool/src/main/resources/docker-files/Update_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Update_Image.mustache
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+# Copyright (c) 2019, 2020, Oracle and/or its affiliates.  All rights reserved.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
@@ -8,17 +8,14 @@
     FROM {{baseImage}} as WDT_BUILD
     LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
-    ARG WDT_PKG
-
-    ENV WDT_PKG=${WDT_PKG:-weblogic-deploy.zip} \
-        WLSDEPLOY_PROPERTIES={{wlsdeploy_properties}} \
+    ENV WLSDEPLOY_PROPERTIES={{wlsdeploy_properties}} \
         LC_ALL=${DEFAULT_LOCALE:-en_US.UTF-8} \
         DOMAIN_HOME={{{domain_home}}} \
         PATH=${PATH}:{{{java_home}}}/bin:{{{oracle_home}}}/oracle_common/common/bin:{{{oracle_home}}}/wlserver/common/bin:{{{domain_home}}}/bin:{{{oracle_home}}}
 
     USER root
 
-    COPY --chown={{userid}}:{{groupid}} ${WDT_PKG} {{{tempDir}}}/
+    COPY --chown={{userid}}:{{groupid}} {{{wdtInstaller}}} {{{tempDir}}}/
 
     RUN mkdir -p {{{wdt_home}}} \
     && chown {{userid}}:{{groupid}} {{{wdt_home}}}
@@ -46,7 +43,7 @@
     {{/beforeWdtCommand}}
 
     RUN cd {{{wdt_home}}} \
-    && jar xf {{{tempDir}}}/$WDT_PKG
+    && jar xf {{{tempDir}}}/{{{wdtInstaller}}}
 
     {{^modelOnly}}
         RUN cd {{{wdt_home}}} \


### PR DESCRIPTION
If the WDT zip file is other than weblogic-deploy.zip, docker build copy failed.