### PR TITLE
added support for folders using additionalBuildFiles feature

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -76,12 +76,16 @@ public abstract class CommonOptions {
             final String FILES_DIR = "files";
             Files.createDirectory(Paths.get(getTempDirectory(), FILES_DIR));
             for (Path additionalFile : additionalBuildFiles) {
-                if (!Files.isRegularFile(additionalFile)) {
+                if (!Files.isReadable(additionalFile)) {
                     throw new FileNotFoundException(Utils.getMessage("IMG-0030", additionalFile));
                 }
                 Path targetFile = Paths.get(getTempDirectory(), FILES_DIR, additionalFile.getFileName().toString());
                 logger.info("IMG-0043", additionalFile);
-                Utils.copyLocalFile(additionalFile.toString(), targetFile.toString(), false);
+                if (Files.isDirectory(additionalFile)) {
+                    Utils.copyLocalDirectory(additionalFile, targetFile, false);
+                } else {
+                    Utils.copyLocalFile(additionalFile, targetFile, false);
+                }
             }
         }
     }

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
@@ -5,6 +5,7 @@ package com.oracle.weblogic.imagetool.cli.menu;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -82,7 +83,7 @@ public class CreateImage extends CommonOptions implements Callable<CommandRespon
             // Set the inventory location, so that it will be copied
             if (inventoryPointerFile != null) {
                 Utils.setInventoryLocation(inventoryPointerFile, dockerfileOptions);
-                Utils.copyLocalFile(inventoryPointerFile, tmpDir + "/oraInst.loc", false);
+                Utils.copyLocalFile(Paths.get(inventoryPointerFile), Paths.get(tmpDir,"/oraInst.loc"), false);
             } else {
                 Utils.copyResourceAsFile("/response-files/oraInst.loc", tmpDir, false);
             }
@@ -95,6 +96,7 @@ public class CreateImage extends CommonOptions implements Callable<CommandRespon
             cmdBuilder.add(tmpDir);
             runDockerCommand(dockerfile, cmdBuilder);
         } catch (Exception ex) {
+            logger.fine("**ERROR**", ex);
             return new CommandResponse(-1, ex.getMessage());
         } finally {
             if (!skipcleanup) {

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
@@ -5,6 +5,7 @@ package com.oracle.weblogic.imagetool.cli.menu;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -145,7 +146,7 @@ public class RebaseImage extends CommonOptions implements Callable<CommandRespon
                 // Set the inventory pointer
                 if (inventoryPointerFile != null) {
                     Utils.setInventoryLocation(inventoryPointerFile, dockerfileOptions);
-                    Utils.copyLocalFile(inventoryPointerFile, tmpDir + "/oraInst.loc", false);
+                    Utils.copyLocalFile(Paths.get(inventoryPointerFile), Paths.get(tmpDir,"/oraInst.loc"), false);
                 } else {
                     Utils.copyResourceAsFile("/response-files/oraInst.loc", tmpDir, false);
                 }

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -5,7 +5,7 @@ IMG-0003=Temporary directory used for docker build context: {0}
 IMG-0004=Invalid patch id {0}. The patch id must be in the format of {1}.  Where the first part is the 8 digit patch ID, and the second half, after the underscore, is the release version for the patch. The release version needs to be specified with 5 places such as 12.2.1.3.0 or 12.2.1.3.190416. Release version is required when adding a patch to the cache or when multiple versions of the same patch number exist for different versions.
 IMG-0005=Installer response file: {0}
 IMG-0006=No patch conflicts detected
-IMG-0007=WDT Download link = {0}
+IMG-0007={0} is not a directory
 IMG-0008=OPatch patch number {0} cached file {1} version {2}
 IMG-0009=skipping patch conflict check, no support credentials provided
 IMG-0010=Oracle Home will be set to {0}
@@ -33,7 +33,7 @@ IMG-0031=No credentials provided. Cannot determine latestPSU
 IMG-0032=Failed to find latest PSU for {0}, version {1}
 IMG-0033=No credentials provided, skipping validation of patches
 IMG-0034=Patch ID {0} has multiple versions, please retry the command using one of the available patch versions: {1}
-IMG-0035=Multiple patches with the same patch number detected
+IMG-0035=additionalBuildFile could not be copied: {0}
 IMG-0036=Unable to find installer inventory file: {0}
 IMG-0037=Failed to find patch {0} for version {1}
 IMG-0038=In image {0}, the Oracle Home already exists at location:

--- a/site/create-image.md
+++ b/site/create-image.md
@@ -62,7 +62,7 @@ LABEL owner="middleware team"
 #### `--additionalBuildFiles`
 
 This option provides a way to supply additional files to the image build command.
-All provided files are copied directly under the `files` subfolder of the build context.  
+All provided files and directories are copied directly under the `files` subfolder of the build context.  
 To get those files into the image, additional build commands must be provided using the `additionalBuildCommands` options.
 Access to these files using a build command, such as `COPY` or `ADD`, should use the original filename 
 with the folder prefix, `files/`.  For example, if the 

--- a/site/rebase-image.md
+++ b/site/rebase-image.md
@@ -56,7 +56,7 @@ LABEL owner="middleware team"
 #### `--additionalBuildFiles`
 
 This option provides a way to supply additional files to the image build command.
-All provided files are copied directly under the `files` subfolder of the build context.  
+All provided files and directories are copied directly under the `files` subfolder of the build context.  
 To get those files into the image, additional build commands must be provided using the `additionalBuildCommands` options.
 Access to these files using a build command, such as `COPY` or `ADD`, should use the original filename 
 with the folder prefix, `files/`.  For example, if the 

--- a/site/update-image.md
+++ b/site/update-image.md
@@ -81,7 +81,7 @@ LABEL owner="middleware team"
 #### `--additionalBuildFiles`
 
 This option provides a way to supply additional files to the image build command.
-All provided files are copied directly under the `files` subfolder of the build context.  
+All provided files and directories are copied directly under the `files` subfolder of the build context.  
 To get those files into the image, additional build commands must be provided using the `additionalBuildCommands` options.
 Access to these files using a build command, such as `COPY` or `ADD`, should use the original filename 
 with the folder prefix, `files/`.  For example, if the 


### PR DESCRIPTION
Fixes #128.  --additionalBuildFiles option allows the user to add additional files to the build context that can be used with custom build commands in --addtionalBuildCommands like COPY or ADD.  This enhancement adds support for folders so that the user can pass a folder name to the additionalBuildFiles option.  The folder name and its contents are then copied to the build content "files" folder.