### PR TITLE
removed All rights reserved from copyright

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017, 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+Copyright (c) 2017, 2020, Oracle Corporation and/or its affiliates.
 
 The Universal Permissive License (UPL), Version 1.0
 

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+<!-- Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
      Licensed under the Universal Permissive License v 1.0 as shown at
      https://oss.oracle.com/licenses/upl. -->
 <project>

--- a/build-tools/src/main/resources/weblogic-image-tool/checkstyle/java.header
+++ b/build-tools/src/main/resources/weblogic-image-tool/checkstyle/java.header
@@ -1,2 +1,2 @@
-^// Copyright \(c\) (\d\d\d\d, )+Oracle Corporation and\/or its affiliates\.  All rights reserved\.$
+^// Copyright \(c\) (\d\d\d\d, )+Oracle Corporation and\/or its affiliates\.$
 ^// Licensed under the Universal Permissive License v 1\.0 as shown at https://oss\.oracle\.com/licenses/upl\.$

--- a/imagetool/pom.xml
+++ b/imagetool/pom.xml
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+<!-- Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
      Licensed under the Universal Permissive License v 1.0 as shown at
      https://oss.oracle.com/licenses/upl. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/imagetool/src/main/bin/imagetool.cmd
+++ b/imagetool/src/main/bin/imagetool.cmd
@@ -2,7 +2,7 @@
 @rem **************************************************************************
 @rem imagetool.cmd
 @rem
-@rem Copyright (c) 2019, Oracle and/or its affiliates.  All rights reserved.
+@rem Copyright (c) 2019, 2020, Oracle and/or its affiliates.
 @rem Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 IF "%JAVA_HOME%" == "" (

--- a/imagetool/src/main/bin/imagetool.sh
+++ b/imagetool/src/main/bin/imagetool.sh
@@ -1,5 +1,5 @@
 #
-#Copyright (c) 2019, Oracle and/or its affiliates.  All rights reserved.
+#Copyright (c) 2019, 2020, Oracle and/or its affiliates.
 #
 #Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #

--- a/imagetool/src/main/bin/setup.sh
+++ b/imagetool/src/main/bin/setup.sh
@@ -1,5 +1,5 @@
 #
-#Copyright (c) 2019, Oracle and/or its affiliates.  All rights reserved.
+#Copyright (c) 2019, 2020, Oracle and/or its affiliates.
 #
 #Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/api/model/CachedFile.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/api/model/CachedFile.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.api.model;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/api/model/CommandResponse.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/api/model/CommandResponse.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.api.model;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cachestore/CacheStore.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cachestore/CacheStore.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cachestore;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cachestore/CacheStoreFactory.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cachestore/CacheStoreFactory.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cachestore;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cachestore/CachedPatchFile.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cachestore/CachedPatchFile.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cachestore;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cachestore/FileCacheStore.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cachestore/FileCacheStore.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cachestore;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/CLIDriver.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/CLIDriver.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/HelpVersionProvider.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/HelpVersionProvider.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/WLSCommandLine.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/WLSCommandLine.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/AddEntry.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/AddEntry.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.cache;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/AddInstallerEntry.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/AddInstallerEntry.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.cache;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/AddPatchEntry.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/AddPatchEntry.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.cache;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/CacheCLI.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/CacheCLI.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.cache;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/CacheOperation.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/CacheOperation.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.cache;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/DeleteEntry.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/DeleteEntry.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.cache;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/GetCacheDir.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/GetCacheDir.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.cache;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/ListCacheItems.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/ListCacheItems.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.cache;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.menu;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.menu;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.menu;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.menu;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/WLSInstallHelper.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/WLSInstallHelper.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.menu;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/WdtOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/WdtOptions.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.menu;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/DefaultResponseFile.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/DefaultResponseFile.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.installer;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.installer;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/InstallerType.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/InstallerType.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.installer;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/MiddlewareInstall.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/MiddlewareInstall.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.installer;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/MiddlewareInstallPackage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/MiddlewareInstallPackage.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.installer;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/ProvidedResponseFile.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/ProvidedResponseFile.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.installer;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/ResponseFile.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/ResponseFile.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.installer;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/logging/FileFormatter.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/logging/FileFormatter.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.logging;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/logging/LoggingFacade.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/logging/LoggingFacade.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.logging;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/logging/LoggingFactory.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/logging/LoggingFactory.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.logging;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/ARUUtil.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/ARUUtil.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.util;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/AdditionalBuildCommands.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/AdditionalBuildCommands.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.util;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/CloseableList.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/CloseableList.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.util;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Constants.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Constants.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.util;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.util;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/HttpUtil.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/HttpUtil.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.util;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/NamedPattern.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/NamedPattern.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.util;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/SearchResult.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/SearchResult.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.util;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.util;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/ValidationResult.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/ValidationResult.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.util;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/XPathUtil.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/XPathUtil.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.util;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/wdt/DomainType.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/wdt/DomainType.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.wdt;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/wdt/WdtOperation.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/wdt/WdtOperation.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.wdt;

--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020, Oracle and/or its affiliates.  All rights reserved.
+# Copyright (c) 2019, 2020, Oracle and/or its affiliates.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #

--- a/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020, Oracle and/or its affiliates.  All rights reserved.
+# Copyright (c) 2019, 2020, Oracle and/or its affiliates.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #

--- a/imagetool/src/main/resources/docker-files/Update_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Update_Image.mustache
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2020, Oracle and/or its affiliates.  All rights reserved.
+# Copyright (c) 2019, 2020, Oracle and/or its affiliates.
 #
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #

--- a/imagetool/src/main/resources/probe-env/test-create-env.sh
+++ b/imagetool/src/main/resources/probe-env/test-create-env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#Copyright (c) 2019, Oracle and/or its affiliates.  All rights reserved.
+#Copyright (c) 2019, 2020, Oracle and/or its affiliates.
 #
 #Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #

--- a/imagetool/src/main/resources/probe-env/test-update-env.sh
+++ b/imagetool/src/main/resources/probe-env/test-update-env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#Copyright (c) 2019, Oracle and/or its affiliates.  All rights reserved.
+#Copyright (c) 2019, 2020, Oracle and/or its affiliates.
 #
 #Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/cachestore/meta/FileCacheStoreTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/cachestore/meta/FileCacheStoreTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cachestore.meta;

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/cli/cache/AddEntryTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/cli/cache/AddEntryTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.cache;

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/cli/cache/AddInstallerEntryTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/cli/cache/AddInstallerEntryTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.cache;

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/integration/BaseTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/integration/BaseTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.integration;

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/integration/ITImagetool.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/integration/ITImagetool.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.integration;

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/integration/utils/ExecCommand.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/integration/utils/ExecCommand.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.integration.utils;

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/integration/utils/ExecResult.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/integration/utils/ExecResult.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.integration.utils;

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/util/AdditionalBuildCommandsTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/util/AdditionalBuildCommandsTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.util;

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/util/DockerfileBuilderTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/util/DockerfileBuilderTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.util;

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/util/UtilsTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/util/UtilsTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.util;

--- a/imagetool/src/test/resources/wdt/build-archive.sh
+++ b/imagetool/src/test/resources/wdt/build-archive.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-#Copyright (c) 2018, 2019, Oracle and/or its affiliates.  All rights reserved.
+#Copyright (c) 2018, 2020, Oracle and/or its affiliates.
 #
 #Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #

--- a/imagetool/src/test/resources/wdt/domain.properties
+++ b/imagetool/src/test/resources/wdt/domain.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+# Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl.
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2019, Oracle Corporation and/or its affiliates.  All rights reserved.
+<!-- Copyright (c) 2019, 2020, Oracle Corporation and/or its affiliates.
      Licensed under the Universal Permissive License v 1.0 as shown at
      https://oss.oracle.com/licenses/upl. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"


### PR DESCRIPTION
As directed by Oracle Corporate, removed "All rights reserved" from Copyright statements. 