### PR TITLE
Prevent RunRCU when not in CREATE

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -139,7 +139,8 @@ public class UpdateImage extends CommonOptions implements Callable<CommandRespon
             // build wdt args if user passes --wdtModelPath
             wdtOptions.handleWdtArgs(dockerfileOptions, cmdBuilder, tmpDir);
             dockerfileOptions.setWdtCommand(wdtOperation);
-            if (wdtOperation == WdtOperation.UPDATE && dockerfileOptions.runRcu()) {
+            if (dockerfileOptions.runRcu()
+                && (wdtOperation == WdtOperation.UPDATE ||  wdtOperation == WdtOperation.DEPLOY)) {
                 return new CommandResponse(-1, "IMG-0055");
             }
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -139,6 +139,9 @@ public class UpdateImage extends CommonOptions implements Callable<CommandRespon
             // build wdt args if user passes --wdtModelPath
             wdtOptions.handleWdtArgs(dockerfileOptions, cmdBuilder, tmpDir);
             dockerfileOptions.setWdtCommand(wdtOperation);
+            if (wdtOperation == WdtOperation.UPDATE && dockerfileOptions.runRcu()) {
+                return new CommandResponse(-1, "IMG-0055");
+            }
 
             // resolve required patches
             handlePatchFiles(lsinventoryText);

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -53,3 +53,4 @@ IMG-0051=Deleted entry {0}={1}
 IMG-0052=Nothing to delete for key: {0}
 IMG-0053=Build successful. Build time={0}s. Image tag={1}
 IMG-0054=Dry run complete.  No image created.
+IMG-0055=RunRCU can only be used when creating a new domain.  Please try --wdtOperation=CREATE or removing --wdtRunRCU.


### PR DESCRIPTION
WDT does not have an option to run RCU for updateDomain.  Run RCU can only be used with WDT createDomain.