### PR TITLE
Add scheme before constructing URL object (the env variable of where …

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
@@ -156,6 +156,9 @@ public class Utils {
     }
 
     private static void setSystemProxy(String proxyUrl, String protocolToSet) throws IOException {
+        if (!proxyUrl.toLowerCase().startsWith(protocolToSet)) {
+            proxyUrl = protocolToSet + "://" + proxyUrl;
+        }
         URL url = new URL(proxyUrl);
         String host = url.getHost();
         int port = url.getPort() == -1 ? url.getDefaultPort() : url.getPort();


### PR DESCRIPTION
This remove the requirement to have the http(s)_proxy environment variable to have a scheme set