### PR TITLE
Fix proxy scheme problem to only add scheme when no scheme is provided.

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
@@ -156,8 +156,10 @@ public class Utils {
     }
 
     private static void setSystemProxy(String proxyUrl, String protocolToSet) throws IOException {
-        if (!proxyUrl.toLowerCase().startsWith(protocolToSet)) {
-            proxyUrl = protocolToSet + "://" + proxyUrl;
+
+        // If no scheme is set then default to http://
+        if (!proxyUrl.toLowerCase().startsWith("http://") && !proxyUrl.toLowerCase().startsWith("https://")) {
+            proxyUrl = "http://" + proxyUrl;
         }
         URL url = new URL(proxyUrl);
         String host = url.getHost();

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
@@ -158,8 +158,9 @@ public class Utils {
     private static void setSystemProxy(String proxyUrl, String protocolToSet) throws IOException {
 
         // If no scheme is set then default to http://
-        if (!proxyUrl.toLowerCase().startsWith("http://") && !proxyUrl.toLowerCase().startsWith("https://")) {
-            proxyUrl = "http://" + proxyUrl;
+        if (!proxyUrl.toLowerCase().startsWith(Constants.HTTP + "://")
+            && !proxyUrl.toLowerCase().startsWith(Constants.HTTPS + "://")) {
+            proxyUrl =  Constants.HTTP + "://" + proxyUrl;
         }
         URL url = new URL(proxyUrl);
         String host = url.getHost();


### PR DESCRIPTION
Default to http:// when it is not provided in the http_proxy or https_proxy environment variable