### PR TITLE
remove option to install OHS product

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/DefaultResponseFile.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/DefaultResponseFile.java
@@ -20,8 +20,6 @@ public class DefaultResponseFile implements ResponseFile {
     private static final String R_FMW = "Fusion Middleware Infrastructure";
     private static final String R_SOA = "SOA Suite";
     private static final String R_OSB = "Service Bus";
-    private static final String R_OHS = "Standalone HTTP Server (Managed independently of WebLogic server)";
-    private static final String R_OHS_WLS = "Collocated HTTP Server (Managed through WebLogic server)";
     private static final String R_IDM =
         "Standalone Oracle Identity and Access Manager(Managed independently of WebLogic server)";
     private static final String R_IDM_WLS =
@@ -57,13 +55,6 @@ public class DefaultResponseFile implements ResponseFile {
                 break;
             case OSB:
                 response = R_OSB;
-                break;
-            case OHS:
-                if (FmwInstallerType.OHS == fmwInstallerType) {
-                    response = R_OHS;
-                } else {
-                    response = R_OHS_WLS;
-                }
                 break;
             case IDM:
                 if (FmwInstallerType.IDM == fmwInstallerType) {

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
@@ -18,8 +18,6 @@ public enum FmwInstallerType {
     IDM(InstallerType.FMW, InstallerType.IDM),
     IDM_WLS(InstallerType.IDM),
     OAM(InstallerType.FMW, InstallerType.OAM), //Identity and Access Manager
-    OHS(InstallerType.OHS),
-    OHS_WLS(InstallerType.FMW, InstallerType.OHS),
     OIG(InstallerType.FMW, InstallerType.SOA, InstallerType.OSB, InstallerType.IDM),
     OUD(InstallerType.OUD), //Oracle Unified Directory
     OUD_WLS(InstallerType.FMW, InstallerType.OUD), //Oracle Unified Directory

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/InstallerType.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/InstallerType.java
@@ -13,7 +13,6 @@ public enum InstallerType {
     FMW("fmw"),
     SOA("soa"),
     OSB("osb"),
-    OHS("ohs"),
     IDM("idm"),
     OAM("oam"),
     OUD("oud"),

--- a/site/create-image.md
+++ b/site/create-image.md
@@ -28,7 +28,7 @@ Usage: imagetool create [OPTIONS]
 | `--passwordFile` | Path to a file containing just the Oracle Support password, see `--user`.  |   |
 | `--patches` | Comma separated list of patch IDs. Example: `12345678,87654321`  |   |
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0`  |   |
-| `--type` | Installer type. Supported values: `WLS`, `FMW`, `IDM`, `OHS_WLS`, `OHS`, `OSB`, `OUD_WLS`, `SOA_OSB`, `WCP`, `OAM`, `OIG`, `OUD`, `SOA`, `WCC`, `WCS`, `WCP`  | `WLS`  |
+| `--type` | Installer type. Supported values: `WLS`, `FMW`, `IDM`, `OSB`, `OUD_WLS`, `SOA_OSB`, `WCP`, `OAM`, `OIG`, `OUD`, `SOA`, `WCC`, `WCS`, `WCP`  | `WLS`  |
 | `--user` | Oracle support email ID.  |   |
 | `--version` | Installer version. | `12.2.1.3.0`  |
 | `--wdtArchive` | Path to the WDT archive file used by the WDT model.  |   |

--- a/site/rebase-image.md
+++ b/site/rebase-image.md
@@ -32,7 +32,7 @@ Usage: imagetool rebase [OPTIONS]
 | `--sourceImage` | (Required) Source Image containing the WebLogic domain. |   |
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0`  |   |
 | `--targetImage` | Docker image to extend for the domain's new image. |   |
-| `--type` | Installer type. Supported values: `WLS`, `FMW`, `IDM`, `OHS_WLS`, `OHS`, `OSB`, `OUD_WLS`, `SOA_OSB`, `WCP`, `OAM`, `OIG`, `OUD`, `SOA`, `WCC`, `WCS`, `WCP`  | `WLS`  |
+| `--type` | Installer type. Supported values: `WLS`, `FMW`, `IDM`, `OSB`, `OUD_WLS`, `SOA_OSB`, `WCP`, `OAM`, `OIG`, `OUD`, `SOA`, `WCC`, `WCS`, `WCP`  | `WLS`  |
 | `--user` | Your Oracle support email ID.  |   |
 | `--version` | Installer version. | `12.2.1.3.0`  |
 


### PR DESCRIPTION
OHS is not an OUI installer, and does not require Java.  OHS is not a good fit for the WebLogic Image Tool.