### PR TITLE
added --pull option for the docker build

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -106,30 +106,18 @@ public abstract class CommonOptions {
      * @return list of options
      */
     DockerBuildCommand getInitialBuildCmd(String contextFolder) {
-
         logger.entering();
         DockerBuildCommand cmdBuilder = new DockerBuildCommand(contextFolder);
 
-        cmdBuilder.setTag(imageTag);
-
-        if (!Utils.isEmptyString(buildNetwork)) {
-            cmdBuilder.addNetworkArg(buildNetwork);
-        }
-
-        if (!Utils.isEmptyString(httpProxyUrl)) {
-            cmdBuilder.addBuildArg("http_proxy", httpProxyUrl);
-        }
-
-        if (!Utils.isEmptyString(httpsProxyUrl)) {
-            cmdBuilder.addBuildArg("https_proxy", httpsProxyUrl);
-        }
-
-        if (!Utils.isEmptyString(nonProxyHosts)) {
-            cmdBuilder.addBuildArg("no_proxy", nonProxyHosts);
-        }
+        cmdBuilder.tag(imageTag)
+            .network(buildNetwork)
+            .pull(buildPull)
+            .buildArg("http_proxy", httpProxyUrl)
+            .buildArg("https_proxy", httpsProxyUrl)
+            .buildArg("no_proxy", nonProxyHosts);
 
         if (dockerPath != null && Files.isExecutable(dockerPath)) {
-            cmdBuilder.setDockerPath(dockerPath.toAbsolutePath().toString());
+            cmdBuilder.dockerPath(dockerPath.toAbsolutePath().toString());
         }
         logger.exiting();
         return cmdBuilder;
@@ -391,6 +379,12 @@ public abstract class CommonOptions {
         description = "Set the networking mode for the RUN instructions during build"
     )
     String buildNetwork;
+
+    @Option(
+        names = {"--pull"},
+        description = "Always attempt to pull a newer version of base images during the build"
+    )
+    boolean buildPull = false;
 
     @SuppressWarnings("unused")
     @Unmatched

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
@@ -114,13 +114,8 @@ public class RebaseImage extends CommonOptions implements Callable<CommandRespon
 
             DockerBuildCommand cmdBuilder = getInitialBuildCmd(tmpDir);
 
-            if (adminPort != null) {
-                cmdBuilder.addBuildArg("ADMIN_PORT", adminPort);
-            }
-
-            if (managedServerPort != null) {
-                cmdBuilder.addBuildArg("MANAGED_SERVER_PORT", managedServerPort);
-            }
+            cmdBuilder.buildArg("ADMIN_PORT", adminPort)
+                .buildArg("MANAGED_SERVER_PORT", managedServerPort);
 
             if (dockerfileOptions.isRebaseToNew()) {
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/WdtOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/WdtOptions.java
@@ -45,7 +45,7 @@ public class WdtOptions {
         String encryptionKey = Utils.getPasswordFromInputs(encryptionKeyStr, encryptionKeyFile, encryptionKeyEnv);
         if (encryptionKey != null) {
             dockerfileOptions.setWdtUseEncryption(true);
-            cmdBuilder.addBuildArg("WDT_ENCRYPTION_KEY", encryptionKey, true);
+            cmdBuilder.buildArg("WDT_ENCRYPTION_KEY", encryptionKey, true);
         }
 
         dockerfileOptions.setWdtEnabled();

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerBuildCommand.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerBuildCommand.java
@@ -41,13 +41,22 @@ public class DockerBuildCommand {
         context = contextFolder;
     }
 
-    public void setDockerPath(String value) {
+    public void dockerPath(String value) {
         command.set(0, value);
     }
 
-    public void setTag(String value) {
+    /**
+     * Add Docker image tag name for this build command.
+     * @param value name to be used as the image tag.
+     * @return this
+     */
+    public DockerBuildCommand tag(String value) {
+        if (Utils.isEmptyString(value)) {
+            return this;
+        }
         command.add("--tag");
         command.add(value);
+        return this;
     }
 
     /**
@@ -56,8 +65,8 @@ public class DockerBuildCommand {
      * @param key the ARG
      * @param value the value to be used in the Dockerfile for this ARG
      */
-    public void addBuildArg(String key, String value) {
-        addBuildArg(key, value, false);
+    public DockerBuildCommand buildArg(String key, String value) {
+        return buildArg(key, value, false);
     }
 
     /**
@@ -66,21 +75,40 @@ public class DockerBuildCommand {
      * @param value the value to be used in the Dockerfile for this ARG
      * @param conceal true for passwords so the value is not logged
      */
-    public void addBuildArg(String key, String value, boolean conceal) {
+    public DockerBuildCommand buildArg(String key, String value, boolean conceal) {
+        if (Utils.isEmptyString(value)) {
+            return this;
+        }
         BuildArg arg = new BuildArg();
         arg.key = key;
         arg.value = value;
         arg.conceal = conceal;
         buildArgs.add(arg);
+        return this;
     }
 
     /**
      * Add a --network to the Docker build command.
      * @param value the Docker network to use
      */
-    public void addNetworkArg(String value) {
+    public DockerBuildCommand network(String value) {
+        if (Utils.isEmptyString(value)) {
+            return this;
+        }
         command.add("--network");
         command.add(value);
+        return this;
+    }
+
+    /**
+     * Add a --pull to the Docker build command.  If value is false, return without adding the --pull.
+     * @param value true to add the pull
+     */
+    public DockerBuildCommand pull(boolean value) {
+        if (value) {
+            command.add("--pull");
+        }
+        return this;
     }
 
     /**
@@ -90,7 +118,7 @@ public class DockerBuildCommand {
      * @throws IOException          if an error occurs reading from the process inputstream.
      * @throws InterruptedException when the process wait is interrupted.
      */
-    public void run(Path dockerLog)
+    public DockerBuildCommand run(Path dockerLog)
         throws IOException, InterruptedException {
         // process builder
         logger.entering(getCommand(false), dockerLog);
@@ -114,6 +142,7 @@ public class DockerBuildCommand {
         if (process.waitFor() != 0) {
             Utils.processError(process);
         }
+        return this;
     }
 
     /**

--- a/site/create-image.md
+++ b/site/create-image.md
@@ -27,6 +27,7 @@ Usage: imagetool create [OPTIONS]
 | `--passwordEnv` | Environment variable containing the Oracle Support password, see `--user`.  |   |
 | `--passwordFile` | Path to a file containing just the Oracle Support password, see `--user`.  |   |
 | `--patches` | Comma separated list of patch IDs. Example: `12345678,87654321`  |   |
+| `--pull` | Always attempt to pull a newer version of base images during the build.  |   |
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0`  |   |
 | `--type` | Installer type. Supported values: `WLS`, `FMW`, `IDM`, `OHS_WLS`, `OHS`, `OSB`, `OUD_WLS`, `SOA_OSB`, `WCP`, `OAM`, `OIG`, `OUD`, `SOA`, `WCC`, `WCS`, `WCP`  | `WLS`  |
 | `--user` | Oracle support email ID.  |   |

--- a/site/rebase-image.md
+++ b/site/rebase-image.md
@@ -29,6 +29,7 @@ Usage: imagetool rebase [OPTIONS]
 | `--passwordEnv` | Environment variable containing the Oracle Support password, see `--user`.  |   |
 | `--passwordFile` | Path to a file containing just the Oracle Support password, see `--user`.  |   |
 | `--patches` | Comma separated list of patch IDs. Example: `12345678,87654321`  |   |
+| `--pull` | Always attempt to pull a newer version of base images during the build.  |   |
 | `--sourceImage` | (Required) Source Image containing the WebLogic domain. |   |
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0`  |   |
 | `--targetImage` | Docker image to extend for the domain's new image. |   |

--- a/site/update-image.md
+++ b/site/update-image.md
@@ -38,6 +38,7 @@ Update WebLogic Docker image with selected patches
 | `--passwordEnv` | Environment variable containing the Oracle Support password, see `--user`.  |   |
 | `--passwordFile` | Path to a file containing just the Oracle Support password, see `--user`.  |   |
 | `--patches` | Comma separated list of patch IDs. Example: `12345678,87654321`  |   |
+| `--pull` | Always attempt to pull a newer version of base images during the build.  |   |
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0`  |   |
 | `--user` | Oracle support email ID.  |   |
 | `--wdtArchive` | Path to the WDT archive file used by the WDT model.  |   |


### PR DESCRIPTION
Fixes #146 
Add an option to enable --pull for the Docker build command.  Enabling the pull option will attempt to pull a newer version of base images during the build.