### PR TITLE
cleanup docker container created during update

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
@@ -450,7 +450,7 @@ public class Utils {
         String oneCommand = String.format("echo %s | base64 -d | /bin/bash", encodedFile);
         logger.finer("ONE COMMAND [" + oneCommand + "]");
         final List<String> retVal = Stream.of(
-            "docker", "run",
+            "docker", "run", "--rm",
             dockerImage, "/bin/bash", "-c", oneCommand).collect(Collectors.toList());
         if (args != null && args.length > 0) {
             retVal.addAll(Arrays.asList(args));

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -6,7 +6,7 @@ IMG-0004=Invalid patch id {0}. The patch id must be in the format of {1}.  Where
 IMG-0005=Installer response file: {0}
 IMG-0006=No patch conflicts detected
 IMG-0007={0} is not a directory
-IMG-0008=Will update OPatch in final image from version {0} to version {1}
+IMG-0008=Updating OPatch in final image from version {0} to version {1}
 IMG-0009=skipping patch conflict check, no support credentials provided
 IMG-0010=Oracle Home will be set to {0}
 IMG-0011=Installer with key="{0}" is not in the local cache, please download the installer and add it to the cache with "imagetool cache addInstaller ..."


### PR DESCRIPTION
By default, Docker leaves containers around indefinitely.  During the imagetool update flow, the tool creates a new container from the image to be updated in order to check the version of WLS and the patches installed.   After exiting, this container is no longer needed.  Adding "--rm" will tell Docker to remove the container after it exits.