### PR TITLE
allow the user to skip update for OPatch version, --skipOpatchUpdate

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -169,6 +169,19 @@ public abstract class CommonOptions {
     }
 
     /**
+     * Should OPatch version be updated.
+     * OPatch should be updated to the latest version available unless the user
+     * requests that OPatch should not be updated.
+     * @return true if OPatch should be updated.
+     */
+    boolean shouldUpdateOpatch() {
+        if (skipOpatchUpdate) {
+            logger.fine("OPatch update was skipped at user's request");
+        }
+        return !skipOpatchUpdate;
+    }
+
+    /**
      * Builds a list of build args to pass on to docker with the required patches.
      * Also, creates links to patches directory under build context instead of copying over.
      *
@@ -382,7 +395,13 @@ public abstract class CommonOptions {
         names = {"--pull"},
         description = "Always attempt to pull a newer version of base images during the build"
     )
-    boolean buildPull = false;
+    private boolean buildPull = false;
+
+    @Option(
+        names = {"--skipOpatchUpdate"},
+        description = "Do not update OPatch version, even if a newer version is available."
+    )
+    private boolean skipOpatchUpdate = false;
 
     @SuppressWarnings("unused")
     @Unmatched

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
@@ -74,7 +74,7 @@ public class CreateImage extends CommonOptions implements Callable<CommandRespon
             handlePatchFiles(null);
 
             // If patching, patch OPatch first
-            if (applyingPatches()) {
+            if (applyingPatches() && shouldUpdateOpatch()) {
                 installOpatchInstaller(tmpDir, opatchBugNumber);
             }
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
@@ -136,7 +136,7 @@ public class RebaseImage extends CommonOptions implements Callable<CommandRespon
                 handlePatchFiles(null);
 
                 // If patching, patch OPatch first
-                if (applyingPatches()) {
+                if (applyingPatches() && shouldUpdateOpatch()) {
                     installOpatchInstaller(tmpDir, opatchBugNumber);
                 }
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -84,16 +84,18 @@ public class UpdateImage extends CommonOptions implements Callable<CommandRespon
                 String userId = getUserId();
                 String password = getPassword();
 
-                OPatchFile opatchFile = new OPatchFile(opatchBugNumber, userId, password, cache());
-                String opatchFilePath = opatchFile.resolve(cache());
+                if (shouldUpdateOpatch()) {
+                    OPatchFile opatchFile = new OPatchFile(opatchBugNumber, userId, password, cache());
+                    String opatchFilePath = opatchFile.resolve(cache());
 
-                // if there is a newer version of OPatch than contained in the image, update OPatch
-                if (Utils.compareVersions(opatchVersion, opatchFile.getVersion()) < 0) {
-                    logger.info("IMG-0008", opatchVersion, opatchFile.getVersion());
-                    String filename = new File(opatchFilePath).getName();
-                    Files.copy(Paths.get(opatchFilePath), Paths.get(tmpDir, filename));
-                    dockerfileOptions.setOPatchPatchingEnabled();
-                    dockerfileOptions.setOPatchFileName(filename);
+                    // if there is a newer version of OPatch than contained in the image, update OPatch
+                    if (Utils.compareVersions(opatchVersion, opatchFile.getVersion()) < 0) {
+                        logger.info("IMG-0008", opatchVersion, opatchFile.getVersion());
+                        String filename = new File(opatchFilePath).getName();
+                        Files.copy(Paths.get(opatchFilePath), Paths.get(tmpDir, filename));
+                        dockerfileOptions.setOPatchPatchingEnabled();
+                        dockerfileOptions.setOPatchFileName(filename);
+                    }
                 }
 
                 logger.finer("Verifying Patches to WLS ");

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -63,3 +63,4 @@ IMG-0061=Could not find key {0} in the cache for patch {1}
 IMG-0062=An OPatch version could not be found in the cache store and you have not provided Oracle Support credentials. Please provide --user with one of the password options or populate the cache store manually.
 IMG-0063=Found matching patch for {0}, but version is {1}
 IMG-0064=Failed to copy file, {0}, from cache to build context directory, {1}
+IMG-0065=Skipping OPatch version update, --skipOPatchUpdate


### PR DESCRIPTION
Added a command line option that allows the user to skip updating OPatch version even if there is a newer one available.  Use of this option requires knowledge of the patches being applied and whether the version of OPatch is sufficient.