### PR TITLE
installer response file names may have the same name

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/ProvidedResponseFile.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/ProvidedResponseFile.java
@@ -16,6 +16,7 @@ public class ProvidedResponseFile implements ResponseFile {
     private static final LoggingFacade logger = LoggingFactory.getLogger(ProvidedResponseFile.class);
 
     private Path responseFileSource;
+    private String filename = null;
 
     /**
      * Use one of the default response files provided in the tool.
@@ -23,18 +24,32 @@ public class ProvidedResponseFile implements ResponseFile {
      */
     public ProvidedResponseFile(Path source) {
         responseFileSource = source;
+        if (responseFileSource != null && Files.isRegularFile(responseFileSource)) {
+            filename = responseFileSource.getFileName().toString();
+        }
     }
 
     @Override
     public String name() {
-        return responseFileSource.getFileName().toString();
+        return filename;
     }
 
     @Override
     public void copyFile(String buildContextDir) throws IOException {
-        if (responseFileSource != null && Files.isRegularFile(responseFileSource)) {
+        if (filename != null) {
             logger.fine("IMG-0005", responseFileSource);
             Path target = Paths.get(buildContextDir, name());
+            if (Files.exists(target)) {
+                int idx = 1;
+                String trialName = filename + idx;
+                target = Paths.get(buildContextDir, trialName);
+                while (Files.exists(target)) {
+                    trialName = filename + ++idx;
+                    target = Paths.get(buildContextDir, trialName);
+                }
+                logger.fine("copying installer response file {0} as {1}", filename, trialName);
+                filename = trialName;
+            }
             Files.copy(responseFileSource, target);
         }
     }

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/ProvidedResponseFile.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/ProvidedResponseFile.java
@@ -36,7 +36,7 @@ public class ProvidedResponseFile implements ResponseFile {
 
     @Override
     public void copyFile(String buildContextDir) throws IOException {
-        if (filename != null) {
+        if (name() != null) {
             logger.fine("IMG-0005", responseFileSource);
             Path target = Paths.get(buildContextDir, name());
             if (Files.exists(target)) {

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/installer/ResponseFileTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/installer/ResponseFileTest.java
@@ -1,0 +1,47 @@
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.weblogic.imagetool.installer;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@Tag("unit")
+public class ResponseFileTest {
+    @Test
+    void copyProvidedResponseFile(@TempDir File tmpDir) throws Exception {
+        String filename = "responseA.txt";
+        Path sourceFile = Paths.get("./src/test/resources/responseFiles/" + filename);
+
+        ResponseFile responseFile0 = new ProvidedResponseFile(sourceFile);
+        assertEquals(filename, responseFile0.name(), "failed to load installer response file name");
+
+        responseFile0.copyFile(tmpDir.getAbsolutePath());
+        assertEquals(filename, responseFile0.name(), "file name should not have changed after copy");
+
+        ResponseFile responseFile1 = new ProvidedResponseFile(sourceFile);
+        responseFile1.copyFile(tmpDir.getAbsolutePath());
+        assertEquals(filename + "1", responseFile1.name(), "file name should have changed after copy");
+
+        ResponseFile responseFile2 = new ProvidedResponseFile(sourceFile);
+        responseFile2.copyFile(tmpDir.getAbsolutePath());
+        assertEquals(filename + "2", responseFile2.name(), "file name should have changed after copy");
+    }
+
+    @Test
+    void notRegularFile(@TempDir File tmpDir) throws Exception {
+        // not a regular file, should skip copy request
+        Path directory = Paths.get("./src/test/resources/responseFiles");
+        ResponseFile responseFile = new ProvidedResponseFile(directory);
+        responseFile.copyFile(tmpDir.getAbsolutePath());
+        assertNull(responseFile.name(), "directories are not valid for a response file");
+    }
+}

--- a/imagetool/src/test/resources/responseFiles/responseA.txt
+++ b/imagetool/src/test/resources/responseFiles/responseA.txt
@@ -1,0 +1,1 @@
+fake file


### PR DESCRIPTION
Fixes #159 
When installer response file names originate from different directories, it is possible that they will have the same simple filename.  When copying those response files to the Docker context folder, rename the target file as needed to accommodate any number of response files that have the same "original" simple name.