### PR TITLE
Fix problems removing temp context directory on Windows platform

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/DefaultResponseFile.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/DefaultResponseFile.java
@@ -102,7 +102,9 @@ public class DefaultResponseFile implements ResponseFile {
         logger.entering(buildContextDir, filename, installTypeResponse);
         MustacheFactory mf = new DefaultMustacheFactory("response-files");
         Mustache mustache = mf.compile("default-response.mustache");
-        mustache.execute(new FileWriter(buildContextDir + File.separator + filename), this).flush();
+        try (FileWriter fw = new FileWriter(buildContextDir + File.separator + filename)) {
+            mustache.execute(fw, this).flush();
+        }
         logger.exiting();
     }
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
@@ -199,7 +199,9 @@ public class Utils {
         throws IOException {
         MustacheFactory mf = new DefaultMustacheFactory("docker-files");
         Mustache mustache = mf.compile(template);
-        mustache.execute(new FileWriter(destPath), options).flush();
+        try (FileWriter fw = new FileWriter(destPath)) {
+            mustache.execute(fw, options).flush();
+        }
 
         if (dryRun) {
             return mustache.execute(new StringWriter(), options).toString();


### PR DESCRIPTION
temp directory on Windows platform not removed because files in the directory were left open.