### PR TITLE
Clarify password command line arguments for create sample

### DIFF
--- a/site/create-image-with-internet.md
+++ b/site/create-image-with-internet.md
@@ -37,7 +37,7 @@ and save them in a directory of your choice, for example, `/home/acmeuser/wls-in
 
    Where ```--user --passwordEnv``` provides the credentials for a user who is entitled to download patches from Oracle Support.
 
- **NOTE**: You can provide the password in one of three ways (see Create Tool for the three command line arguments):
+ **NOTE**: You can provide the password in one of three ways (see Create Tool for the three command-line arguments):
 
  * Plain text
  * Environment variable

--- a/site/create-image-with-internet.md
+++ b/site/create-image-with-internet.md
@@ -37,7 +37,7 @@ and save them in a directory of your choice, for example, `/home/acmeuser/wls-in
 
    Where ```--user --passwordEnv``` provides the credentials for a user who is entitled to download patches from Oracle Support.
 
- **NOTE**: You can provide the password in one of three ways:
+ **NOTE**: You can provide the password in one of three ways (see Create Tool for the three command line arguments):
 
  * Plain text
  * Environment variable

--- a/site/create-image-with-internet.md
+++ b/site/create-image-with-internet.md
@@ -37,11 +37,11 @@ and save them in a directory of your choice, for example, `/home/acmeuser/wls-in
 
    Where ```--user --passwordEnv``` provides the credentials for a user who is entitled to download patches from Oracle Support.
 
- **NOTE**: You can provide the password in one of three ways (see Create Tool for the three command-line arguments):
+ **NOTE**: You can provide the password in one of three ways:
 
- * Plain text
- * Environment variable
- * File containing the password
+ * Plain text --password
+ * Environment variable --passwordEnv
+ * File containing the password --passwordFile
 
 
 You will see the Docker command output as the tool runs:

--- a/site/create-image-with-internet.md
+++ b/site/create-image-with-internet.md
@@ -39,7 +39,7 @@ and save them in a directory of your choice, for example, `/home/acmeuser/wls-in
 
  **NOTE**: You can provide the password in one of three ways:
 
- * Plain text --password
+ * Read from STDIN --password
  * Environment variable --passwordEnv
  * File containing the password --passwordFile
 


### PR DESCRIPTION
I did not look to see that there were different CLA for each password type when following the sample create image documentation. Clarifying for any others like me.