### PR TITLE
resolve parameters in template files with image knowledge

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -24,6 +25,7 @@ import com.oracle.weblogic.imagetool.util.AruUtil;
 import com.oracle.weblogic.imagetool.util.Constants;
 import com.oracle.weblogic.imagetool.util.DockerBuildCommand;
 import com.oracle.weblogic.imagetool.util.DockerfileOptions;
+import com.oracle.weblogic.imagetool.util.ResolverOptions;
 import com.oracle.weblogic.imagetool.util.Utils;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Unmatched;
@@ -33,6 +35,7 @@ import static com.oracle.weblogic.imagetool.cachestore.CacheStoreFactory.cache;
 public abstract class CommonOptions {
     private static final LoggingFacade logger = LoggingFactory.getLogger(CommonOptions.class);
     DockerfileOptions dockerfileOptions;
+    private List<Object> resolveOptions;
     private String tempDirectory = null;
     private String nonProxyHosts = null;
 
@@ -165,6 +168,13 @@ public abstract class CommonOptions {
         handleAdditionalBuildCommands();
 
         logger.exiting();
+    }
+
+    List<Object> resolveOptions() {
+        if (resolveFiles != null) {
+            resolveOptions = Collections.singletonList(new ResolverOptions(imageTag, dockerfileOptions.domain_home()));
+        }
+        return resolveOptions;
     }
 
     /**
@@ -431,6 +441,12 @@ public abstract class CommonOptions {
         description = "Do not update OPatch version, even if a newer version is available."
     )
     private boolean skipOpatchUpdate = false;
+
+    @Option(
+        names = {"--resolveFiles"},
+        description = "Files with parameters that need to be resolved by values in the images tool."
+    )
+    List<String> resolveFiles;
 
     @SuppressWarnings("unused")
     @Unmatched

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -25,8 +25,8 @@ import com.oracle.weblogic.imagetool.util.AruUtil;
 import com.oracle.weblogic.imagetool.util.Constants;
 import com.oracle.weblogic.imagetool.util.DockerBuildCommand;
 import com.oracle.weblogic.imagetool.util.DockerfileOptions;
-import com.oracle.weblogic.imagetool.util.ResolverOptions;
 import com.oracle.weblogic.imagetool.util.Utils;
+import com.oracle.weblogic.imagetool.util.VerrazzanoModel;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Unmatched;
 
@@ -35,9 +35,11 @@ import static com.oracle.weblogic.imagetool.cachestore.CacheStoreFactory.cache;
 public abstract class CommonOptions {
     private static final LoggingFacade logger = LoggingFactory.getLogger(CommonOptions.class);
     DockerfileOptions dockerfileOptions;
-    private List<Object> resolveOptions;
     private String tempDirectory = null;
     private String nonProxyHosts = null;
+
+    private List<Object> resolveOptions = null;
+    private List<Path> resolveFiles = null;
 
     abstract String getInstallerVersion();
 
@@ -170,9 +172,19 @@ public abstract class CommonOptions {
         logger.exiting();
     }
 
+    List<Path> gatherFiles() {
+        if (resolveFiles == null) {
+            resolveFiles = new ArrayList<>();
+        }
+        if (verrazzanoModel != null) {
+            resolveFiles.add(verrazzanoModel);
+        }
+        return resolveFiles;
+    }
+
     List<Object> resolveOptions() {
-        if (resolveFiles != null) {
-            resolveOptions = Collections.singletonList(new ResolverOptions(imageTag, dockerfileOptions.domain_home()));
+        if (resolveFiles != null && !resolveFiles.isEmpty()) {
+            resolveOptions = Collections.singletonList(new VerrazzanoModel(imageTag, dockerfileOptions.domain_home()));
         }
         return resolveOptions;
     }
@@ -443,10 +455,10 @@ public abstract class CommonOptions {
     private boolean skipOpatchUpdate = false;
 
     @Option(
-        names = {"--resolveFiles"},
-        description = "Files with parameters that need to be resolved by values in the images tool."
+        names = {"--vzModel"},
+        description = "For verrazzano, resolve parameters in the verrazzano model with information from the image tool."
     )
-    List<String> resolveFiles;
+    Path verrazzanoModel;
 
     @SuppressWarnings("unused")
     @Unmatched

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
@@ -95,6 +95,8 @@ public class CreateImage extends CommonOptions implements Callable<CommandRespon
             String dockerfile = Utils.writeDockerfile(tmpDir + File.separator + "Dockerfile",
                 "Create_Image.mustache", dockerfileOptions, dryRun);
 
+            Utils.writeResolvedFiles(resolveFiles, resolveOptions());
+
             runDockerCommand(dockerfile, cmdBuilder);
         } catch (Exception ex) {
             logger.fine("**ERROR**", ex);

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
@@ -95,7 +95,8 @@ public class CreateImage extends CommonOptions implements Callable<CommandRespon
             String dockerfile = Utils.writeDockerfile(tmpDir + File.separator + "Dockerfile",
                 "Create_Image.mustache", dockerfileOptions, dryRun);
 
-            Utils.writeResolvedFiles(resolveFiles, resolveOptions());
+            // resolve parameters in the list of mustache templates returned by gatherFiles()
+            Utils.writeResolvedFiles(gatherFiles(), resolveOptions());
 
             runDockerCommand(dockerfile, cmdBuilder);
         } catch (Exception ex) {

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -152,6 +152,9 @@ public class UpdateImage extends CommonOptions implements Callable<CommandRespon
             String dockerfile = Utils.writeDockerfile(tmpDir + File.separator + "Dockerfile",
                 "Update_Image.mustache", dockerfileOptions, dryRun);
 
+            // resolve parameters in the --resolveFiles file list (mustache templates)
+            Utils.writeResolvedFiles(resolveFiles, resolveOptions());
+
             runDockerCommand(dockerfile, cmdBuilder);
         } catch (Exception ex) {
             return new CommandResponse(-1, ex.getMessage());

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -152,8 +152,8 @@ public class UpdateImage extends CommonOptions implements Callable<CommandRespon
             String dockerfile = Utils.writeDockerfile(tmpDir + File.separator + "Dockerfile",
                 "Update_Image.mustache", dockerfileOptions, dryRun);
 
-            // resolve parameters in the --resolveFiles file list (mustache templates)
-            Utils.writeResolvedFiles(resolveFiles, resolveOptions());
+            // resolve parameters in the list of mustache templates returned by gatherFiles()
+            Utils.writeResolvedFiles(gatherFiles(), resolveOptions());
 
             runDockerCommand(dockerfile, cmdBuilder);
         } catch (Exception ex) {

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/ResolverOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/ResolverOptions.java
@@ -1,0 +1,45 @@
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.weblogic.imagetool.util;
+
+/**
+ * Mustache collection of options used to resolve values in a list of mustache templates
+ * as provided with the --resolverFiles command line argument.
+ */
+public class ResolverOptions {
+
+    private String imageName;
+    private String domainHome;
+
+
+    /**
+     * Construct file with the options.
+     *
+     * @param imageName name from the image tag argument
+     * @param domainHome domain home argument or default if no argument
+     */
+    public ResolverOptions(String imageName, String domainHome) {
+        this.imageName = imageName;
+        this.domainHome = domainHome;
+    }
+
+    /**
+     * Return the image name value passed in the image tag argument.
+     *
+     * @return image tag name
+     */
+    public String imageName() {
+        return imageName;
+    }
+
+    /**
+     * Return the domain home passed in the domain home argument or the default if not passed as
+     * an argument.
+     *
+     * @return domain home value
+     */
+    public String domainHome() {
+        return domainHome;
+    }
+}

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
@@ -211,6 +211,38 @@ public class Utils {
     }
 
     /**
+     * Resolve the parameters in the list of Mustache templates with values passed in command line
+     * arguments or other values described by the image tool.
+     * @param fileNames list of file names with mustache parameters to be resolved
+     * @param options list of option files to resolve the mustache parameters
+     * @throws IOException if a file in the fileNames is invalid
+     */
+    public static void writeResolvedFiles(List<String> fileNames, List<Object> options)
+        throws IOException {
+        if (fileNames != null) {
+            for (String fileName : fileNames) {
+                logger.fine("writeResolvedFiles: resolve parameters in file {0}", fileName);
+                File template = new File(fileName);
+                File directory = template.getParentFile();
+                if (directory == null
+                    || !(template.isFile() && template.canRead() && template.canWrite())) {
+                    throw new IllegalArgumentException(getMessage("IMG-0073", template.toString()));
+                }
+
+                MustacheFactory mf = new DefaultMustacheFactory(directory);
+                Mustache mustache;
+                try (FileReader fr = new FileReader(template)) {
+                    mustache = mf.compile(fr, fileName);
+                }
+                try (FileWriter fw = new FileWriter(template)) {
+                    mustache.execute(fw, options).flush();
+                }
+            }
+        }
+
+    }
+
+    /**
      * Executes the given docker command and returns the stdout of the process as properties.
      *
      * @param cmdBuilder command to execute

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
@@ -213,28 +213,28 @@ public class Utils {
     /**
      * Resolve the parameters in the list of Mustache templates with values passed in command line
      * arguments or other values described by the image tool.
-     * @param fileNames list of file names with mustache parameters to be resolved
+     * @param paths list of file paths that are mustache templates
      * @param options list of option files to resolve the mustache parameters
      * @throws IOException if a file in the fileNames is invalid
      */
-    public static void writeResolvedFiles(List<String> fileNames, List<Object> options)
+    public static void writeResolvedFiles(List<Path> paths, List<Object> options)
         throws IOException {
-        if (fileNames != null) {
-            for (String fileName : fileNames) {
-                logger.fine("writeResolvedFiles: resolve parameters in file {0}", fileName);
-                File template = new File(fileName);
-                File directory = template.getParentFile();
+        if (paths != null) {
+            for (Path path : paths) {
+                logger.fine("writeResolvedFiles: resolve parameters in file {0}", path);
+                File directory = path.toFile().getParentFile();
                 if (directory == null
-                    || !(template.isFile() && template.canRead() && template.canWrite())) {
-                    throw new IllegalArgumentException(getMessage("IMG-0073", template.toString()));
+                    || !(Files.exists(path) && Files.isReadable(path) && Files.isWritable(path))) {
+                    throw new IllegalArgumentException(getMessage("IMG-0073", path));
                 }
 
                 MustacheFactory mf = new DefaultMustacheFactory(directory);
                 Mustache mustache;
-                try (FileReader fr = new FileReader(template)) {
-                    mustache = mf.compile(fr, fileName);
+                try (FileReader fr = new FileReader(path.toFile())) {
+                    mustache = mf.compile(fr, path.getFileName().toString());
                 }
-                try (FileWriter fw = new FileWriter(template)) {
+
+                try (FileWriter fw = new FileWriter(path.toFile())) {
                     mustache.execute(fw, options).flush();
                 }
             }

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/VerrazzanoModel.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/VerrazzanoModel.java
@@ -4,10 +4,10 @@
 package com.oracle.weblogic.imagetool.util;
 
 /**
- * Mustache collection of options used to resolve values in a list of mustache templates
+ * Mustache collection of options used to resolve values for the Verrazzano Model
  * as provided with the --resolverFiles command line argument.
  */
-public class ResolverOptions {
+public class VerrazzanoModel {
 
     private String imageName;
     private String domainHome;
@@ -19,7 +19,7 @@ public class ResolverOptions {
      * @param imageName name from the image tag argument
      * @param domainHome domain home argument or default if no argument
      */
-    public ResolverOptions(String imageName, String domainHome) {
+    public VerrazzanoModel(String imageName, String domainHome) {
         this.imageName = imageName;
         this.domainHome = domainHome;
     }

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -71,3 +71,4 @@ IMG-0069=No recommended patches for {0}, version {1}
 IMG-0070=Failed to find latest patches for {0}, version {1}
 IMG-0071=WDT Operation is set to UPDATE, but the DOMAIN_HOME environment variable was not defined in the base image, {0}.  Did you mean to use "--wdtOperation CREATE" to create a new domain?
 IMG-0072=ORACLE_HOME environment variable is not defined in the base image: {0}
+IMG-0073=Invalid file {0} listed in --resolveFiles

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -71,4 +71,4 @@ IMG-0069=No recommended patches for {0}, version {1}
 IMG-0070=Failed to find latest patches for {0}, version {1}
 IMG-0071=WDT Operation is set to UPDATE, but the DOMAIN_HOME environment variable was not defined in the base image, {0}.  Did you mean to use "--wdtOperation CREATE" to create a new domain?
 IMG-0072=ORACLE_HOME environment variable is not defined in the base image: {0}
-IMG-0073=Invalid file {0} listed in --resolveFiles
+IMG-0073=Invalid file {0} listed for Verrazzano model

--- a/imagetool/src/test/resources/templates/resolver.yml
+++ b/imagetool/src/test/resources/templates/resolver.yml
@@ -1,0 +1,2 @@
+domainHome: {{{domainHome}}}
+image: {{{imageName}}}

--- a/imagetool/src/test/resources/templates/verrazzano.yml
+++ b/imagetool/src/test/resources/templates/verrazzano.yml
@@ -1,0 +1,42 @@
+apiVersion: verrazzano.io/v1beta1
+kind: VerrazzanoModel
+metadata:
+  name: dereks-todo-model
+  namespace: default
+spec:
+  description: "Derek's Todo System"
+  weblogicDomains:
+    - name: todo
+      adminPort: 32701
+      t3Port: 32702
+      domainCRValues:
+        domainUID: todo
+        domainHome: {{{domainHome}}}
+        image: {{{imageName}}}
+        includeServerOutInPodLog: true
+        replicas: 1
+        webLogicCredentialsSecret:
+          name: todo-weblogic-credentials
+        imagePullSecrets:
+          - name: ocir
+        clusters:
+          - clusterName: cluster-1
+        serverPod:
+          env:
+            - name: JAVA_OPTIONS
+              value: "-Dweblogic.StdoutDebugEnabled=false"
+            - name: USER_MEM_ARGS
+              value: "-Djava.security.egd=file:/dev/./urandom -Xms64m -Xmx256m "
+            - name: WL_HOME
+              value: /u01/oracle/wlserver
+            - name: MW_HOME
+              value: /u01/oracle
+      connections:
+        - ingress:
+            - name: todo-ingress
+              match:
+                - uri:
+                    prefix: "/todo"
+        - database:
+            - target: todo-db
+              datasourceName: todoDb


### PR DESCRIPTION
Resolve the parameters in the list of mustache templates specified with new command line argument --resolveFiles. This command line argument takes a comma separated list of path/file names.

The options used to resolve the parameters are from knowledge that the image tool has, such as from the input on the command line.

The options are contained in a single generic file, but can be broken out into multiple files as the mustache command takes in a list of option files.