### PR TITLE
Update Guava dependency to pickup security fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>19.0</version>
+                <version>29.0-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.github.spullara.mustache.java</groupId>
@@ -90,7 +90,7 @@
             <dependency>
                 <groupId>org.jetbrains</groupId>
                 <artifactId>annotations</artifactId>
-                <version>17.0.0</version>
+                <version>19.0.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
The Guava security issue fixed in v24.1.1 mainly affects long-running server technologies like application servers.  The dependency checker flagged this issue this morning.  Uptake of newer Guava version to ensure users are protected.