### PR TITLE
Deprecated --type argument for AddPatchEntry

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/AddPatchEntry.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/AddPatchEntry.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 import com.oracle.weblogic.imagetool.api.model.CommandResponse;
 import com.oracle.weblogic.imagetool.cachestore.CacheStoreException;
-import com.oracle.weblogic.imagetool.installer.FmwInstallerType;
 import com.oracle.weblogic.imagetool.logging.LoggingFacade;
 import com.oracle.weblogic.imagetool.logging.LoggingFactory;
 import com.oracle.weblogic.imagetool.util.Utils;
@@ -30,6 +29,10 @@ public class AddPatchEntry extends CacheOperation {
 
     @Override
     public CommandResponse call() throws Exception {
+
+        if (type != null) {
+            logger.warning("[[cyan: --type]] is [[brightred: DEPRECATED]] and will be removed in an upcoming release.");
+        }
 
         if (patchId != null && !patchId.isEmpty()
                 && location != null && Files.exists(location)
@@ -61,26 +64,12 @@ public class AddPatchEntry extends CacheOperation {
      * @return CLI command response
      */
     private CommandResponse addToCache(String patchNumber) throws CacheStoreException {
-        logger.info("adding key " + patchNumber);
-
-        // Check if it is an Opatch patch
-        //String opatchNumber = Utils.getOpatchVersionFromZip(location.toAbsolutePath().toString());
-        //if (opatchNumber != null) {
-        //    int lastSeparator = key.lastIndexOf(CacheStore.CACHE_KEY_SEPARATOR);
-        //    key = key.substring(0, lastSeparator) + CacheStore.CACHE_KEY_SEPARATOR + Constants.OPATCH_PATCH_TYPE;
-        //}
-        logger.info("adding key " + patchNumber);
         if (cache().getValueFromCache(patchNumber) != null) {
-            String error = String.format("Cache key %s already exists, remove it first", patchNumber);
-            logger.severe(error);
-            throw new IllegalArgumentException(error);
+            return new CommandResponse(-1, "IMG-0076", patchNumber);
         }
         cache().addToCache(patchNumber, location.toAbsolutePath().toString());
-        String msg = String.format("Added Patch entry %s=%s for %s", patchNumber, location.toAbsolutePath(), type);
-        logger.info(msg);
-        return new CommandResponse(0, msg);
+        return new CommandResponse(0, Utils.getMessage("IMG-0075", patchNumber, location.toAbsolutePath()));
     }
-
 
     @Option(
             names = {"--patchId"},
@@ -91,12 +80,10 @@ public class AddPatchEntry extends CacheOperation {
 
     @Option(
             names = {"--type"},
-            description = "Type of patch. Valid values: ${COMPLETION-CANDIDATES}",
-            required = true,
-            defaultValue = "wls"
+            description = "Type of patch. DEPRECATED"
     )
-    private FmwInstallerType type;
-
+    @Deprecated
+    private String type;
 
     @Option(
             names = {"--path"},

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -49,7 +49,7 @@ IMG-0047=cache is empty
 IMG-0048=Installer already exists {0}={1}. Try removing it, before adding it again:  deleteEntry --key={0}
 IMG-0049=Could not find value for --path, file not found: {0}
 IMG-0050=Successfully added to cache. {0}={1}
-IMG-0051=Deleted entry {0}={1}
+IMG-0051=Deleted entry [[cyan: {0}]]={1}
 IMG-0052=Nothing to delete for key: {0}
 IMG-0053=[[brightgreen: Build successful.]] Build time={0}s. Image tag={1}
 IMG-0054=[[brightgreen: Dry run complete.]]  No image created.
@@ -73,3 +73,5 @@ IMG-0071=WDT Operation is set to UPDATE, but the DOMAIN_HOME environment variabl
 IMG-0072=ORACLE_HOME environment variable is not defined in the base image: {0}
 IMG-0073=Invalid file {0} listed for Verrazzano model
 IMG-0074=OPatch will not be updated, fromImage has version {0}, available version is {1}
+IMG-0075=Added patch entry [[cyan: {0}]]={1}
+IMG-0076=Cache key {0} already exists, remove it first

--- a/site/cache.md
+++ b/site/cache.md
@@ -20,8 +20,8 @@ List and set cache options
 | Option | Description |
 | --- | --- |
 |`listItems`| List cache contents. |
-|`addInstaller` | Add cache entry for `wls`, `fmw`, `jdk`, or `wdt` installer. |
-| `addPatch` | Add cache entry for `wls` or `fmw` patch, or `psu`.  |
+|`addInstaller` | Add an installer to the cache. |
+| `addPatch` | Add a patch to the cache.  |
 | `addEntry` | Add a cache entry. Use with caution. |  
 | `help` | Display help information for the specified command.|
 
@@ -46,13 +46,13 @@ List and set cache options
     imagetool cache addInstaller --type jdk --version 8u202 --path /path/to/local/jdk.tar.gz
     ```
 
-- `addPatch`: Add a patch to the cache. This command verifies if the path points to a valid patch by querying the Oracle Support portal.
+- `addPatch`: Add a patch to the cache. 
     ```
-    imagetool cache addPatch --type wls --patchId 12345678_12.2.1.3.0 --path /path/to/patch.zip
+    imagetool cache addPatch --patchId 12345678_12.2.1.3.0 --path /path/to/patch.zip
     ```
-    **Note**:  When adding a patch to the cache store, the `patchId` should be in the following format:  `99999999_9.9.9.9.99999`  The first 8 digits is the patch ID, followed by an underscore, and then the release number.  This is needed if you want to distinguish a patch that has different patch versions.  
+    **Note**:  When adding a patch to the cache store, the `patchId` should be in the following format:  `99999999_9.9.9.9.99999`  The first 8 digits is the patch ID, followed by an underscore, and then the release number to identify the patch between different patch versions.  
 
-    For example, patch `29135930` has several different versions in Oracle Support, one for each release in which the bug is fixed.
+    For example, patch `29135930` has several different versions in Oracle Support, one for each release or PSU in which the bug is fixed.
 
 | Patch Name | Release |
 | ---------|---------|

--- a/tests/src/test/java/com/oracle/weblogic/imagetool/tests/BaseTest.java
+++ b/tests/src/test/java/com/oracle/weblogic/imagetool/tests/BaseTest.java
@@ -49,7 +49,7 @@ public class BaseTest {
         return result;
     }
 
-    protected static void validateEnvironmentSettings() throws Exception {
+    protected static void validateEnvironmentSettings() {
         logger.info("Initializing the tests ...");
 
         projectRoot = System.getProperty("user.dir");
@@ -230,9 +230,8 @@ public class BaseTest {
         return executeAndVerify(command, false);
     }
 
-    protected ExecResult addPatchToCache(String type, String patchId, String version, String path) throws Exception {
-        String command = imagetool + " cache addPatch --type " + type + " --patchId " + patchId + "_"
-            + version + " --path " + path;
+    protected ExecResult addPatchToCache(String patchId, String version, String path) throws Exception {
+        String command = imagetool + " cache addPatch --patchId " + patchId + "_" + version + " --path " + path;
         return executeAndVerify(command, false);
     }
 

--- a/tests/src/test/java/com/oracle/weblogic/imagetool/tests/ITImagetool.java
+++ b/tests/src/test/java/com/oracle/weblogic/imagetool/tests/ITImagetool.java
@@ -178,7 +178,7 @@ class ITImagetool extends BaseTest {
 
         String patchPath = getStagingDir() + FS + P27342434_INSTALLER;
         deleteEntryFromCache(P27342434_ID + "_" + WLS_VERSION);
-        addPatchToCache("wls", P27342434_ID, WLS_VERSION, patchPath);
+        addPatchToCache(P27342434_ID, WLS_VERSION, patchPath);
 
         // verify the result
         ExecResult result = listItemsInCache();
@@ -247,7 +247,7 @@ class ITImagetool extends BaseTest {
         // need to add the required patches 28186730 for Opatch before create wls images
         String patchPath = getStagingDir() + FS + P28186730_INSTALLER;
         deleteEntryFromCache(P28186730_ID + "_" + OPATCH_VERSION);
-        addPatchToCache("wls", P28186730_ID, OPATCH_VERSION, patchPath);
+        addPatchToCache(P28186730_ID, OPATCH_VERSION, patchPath);
         ExecResult resultT = listItemsInCache();
 
         String versionTag = "test8img";
@@ -323,12 +323,12 @@ class ITImagetool extends BaseTest {
         // delete the cache entry first
         deleteEntryFromCache(P28186730_ID + "_" + OPATCH_VERSION);
         String patchPath = getStagingDir() + FS + P28186730_INSTALLER;
-        addPatchToCache("wls", P28186730_ID, OPATCH_VERSION, patchPath);
+        addPatchToCache(P28186730_ID, OPATCH_VERSION, patchPath);
 
         // add the patch to the cache
         deleteEntryFromCache(P27342434_ID + "_" + WLS_VERSION);
         patchPath = getStagingDir() + FS + P27342434_INSTALLER;
-        addPatchToCache("wls", P27342434_ID, WLS_VERSION, patchPath);
+        addPatchToCache(P27342434_ID, WLS_VERSION, patchPath);
 
         // build the wdt archive
         buildWdtArchive();
@@ -412,7 +412,7 @@ class ITImagetool extends BaseTest {
         // add the patch to the cache
         String patchPath = getStagingDir() + FS + P22987840_INSTALLER;
         deleteEntryFromCache(P22987840_ID + "_" + WLS_VERSION_1221);
-        addPatchToCache("fmw", P22987840_ID, WLS_VERSION_1221, patchPath);
+        addPatchToCache(P22987840_ID, WLS_VERSION_1221, patchPath);
 
         String command = imagetool + " create --jdkVersion " + JDK_VERSION_8u212 + " --version=" + WLS_VERSION_1221
             + " --tag " + build_tag + ":" + testMethodName + " --patches " + P22987840_ID + " --type fmw";
@@ -577,7 +577,7 @@ class ITImagetool extends BaseTest {
         // delete the cache entry first
         deleteEntryFromCache(P28186730_ID + "_" + OPATCH_VERSION);
         String patchPath = getStagingDir() + FS + P28186730_INSTALLER;
-        addPatchToCache("wls", P28186730_ID, OPATCH_VERSION, patchPath);
+        addPatchToCache(P28186730_ID, OPATCH_VERSION, patchPath);
 
         // build the wdt archive
         buildWdtArchive();


### PR DESCRIPTION
The --type argument for AddPatchEntry was never used and is causing confusion to the users since the additional installer types were added.