### PR TITLE
Added nightly builds with full system tests to Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,11 @@ pipeline {
         jdk 'jdk11'
     }
 
+    triggers {
+        // timer trigger for "nightly build" on master branch
+        cron( env.BRANCH_NAME.equals('master') ? 'H H(0-3) * * 1-5' : '')
+    }
+
     environment {
         STAGING_DIR = "/scratch/artifacts/imagetool"
     }
@@ -28,6 +33,11 @@ pipeline {
             }
         }
         stage ('Test') {
+            when {
+                not {
+                    changelog '\\[skip-ci\\]'
+                }
+            }
             steps {
                 sh 'mvn test'
             }
@@ -37,13 +47,36 @@ pipeline {
                 }
             }
         }
-        stage ('SystemTest') {
+        stage ('SystemTest Gate') {
             when {
-                changeRequest()
+                allOf {
+                    changeRequest target: 'master'
+                    not {
+                        changelog '\\[skip-ci\\]'
+                    }
+                }
             }
             steps {
                 withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'otn-cred', passwordVariable: 'ORACLE_SUPPORT_PASSWORD', usernameVariable: 'ORACLE_SUPPORT_USERNAME']]) {
-                    sh 'mvn verify -Dtest.staging.dir=${STAGING_DIR}'
+                    sh 'mvn verify -Dtest.staging.dir=${STAGING_DIR} -Dtest.groups=gate'
+                }
+            }
+            post {
+                always {
+                    junit 'tests/target/failsafe-reports/*.xml'
+                }
+            }
+        }
+        stage ('SystemTest Full') {
+            when {
+                anyOf {
+                    triggeredBy 'TimerTrigger'
+                    tag "release-*"
+                }
+            }
+            steps {
+                withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'otn-cred', passwordVariable: 'ORACLE_SUPPORT_PASSWORD', usernameVariable: 'ORACLE_SUPPORT_USERNAME']]) {
+                    sh 'mvn verify -Dtest.staging.dir=${STAGING_DIR} -Dtest.groups=gate,nightly'
                 }
             }
             post {

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <test.groups>unit</test.groups>
+        <test.groups>gate</test.groups>
         <aggregate.report.dir>tests/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
     </properties>
 
@@ -124,6 +124,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>2.22.2</version>
+                    <configuration>
+                        <groups>${test.groups}</groups>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -216,8 +219,8 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.2</version>
                     <configuration>
-                        <groups>${test.groups}</groups>
-                        <excludedGroups>slow,failing</excludedGroups>
+                        <groups>unit</groups>
+                        <excludedGroups>failing</excludedGroups>
                         <environmentVariables>
                             <TEST_ENV_PASSWORD>pass3</TEST_ENV_PASSWORD>
                         </environmentVariables>

--- a/tests/src/test/java/com/oracle/weblogic/imagetool/tests/ITImagetool.java
+++ b/tests/src/test/java/com/oracle/weblogic/imagetool/tests/ITImagetool.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
@@ -85,6 +86,7 @@ class ITImagetool extends BaseTest {
      */
     @Test
     @Order(1)
+    @Tag("gate")
     void cacheListItems() throws Exception {
         String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
         logTestBegin(testMethodName);
@@ -105,6 +107,7 @@ class ITImagetool extends BaseTest {
      */
     @Test
     @Order(2)
+    @Tag("gate")
     void cacheAddInstallerJDK() throws Exception {
         String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
         logTestBegin(testMethodName);
@@ -127,6 +130,7 @@ class ITImagetool extends BaseTest {
      */
     @Test
     @Order(3)
+    @Tag("gate")
     void cacheAddInstallerWls() throws Exception {
         String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
         logTestBegin(testMethodName);
@@ -149,6 +153,7 @@ class ITImagetool extends BaseTest {
      */
     @Test
     @Order(4)
+    @Tag("nightly")
     void createWlsImg() throws Exception {
         String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
         logTestBegin(testMethodName);
@@ -172,6 +177,7 @@ class ITImagetool extends BaseTest {
      */
     @Test
     @Order(5)
+    @Tag("gate")
     void cacheAddPatch() throws Exception {
         String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
         logTestBegin(testMethodName);
@@ -195,6 +201,7 @@ class ITImagetool extends BaseTest {
      */
     @Test
     @Order(6)
+    @Tag("gate")
     void cacheAddTestEntry() throws Exception {
         String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
         logTestBegin(testMethodName);
@@ -217,6 +224,7 @@ class ITImagetool extends BaseTest {
      */
     @Test
     @Order(7)
+    @Tag("gate")
     void cacheDeleteTestEntry() throws Exception {
         String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
         logTestBegin(testMethodName);
@@ -240,6 +248,7 @@ class ITImagetool extends BaseTest {
      */
     @Test
     @Order(8)
+    @Tag("gate")
     void createWLSImgUseCache() throws Exception {
         String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
         logTestBegin(testMethodName);
@@ -271,6 +280,7 @@ class ITImagetool extends BaseTest {
      */
     @Test
     @Order(9)
+    @Tag("gate")
     void updateWLSImg() throws Exception {
         String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
         logTestBegin(testMethodName);
@@ -296,6 +306,7 @@ class ITImagetool extends BaseTest {
      */
     @Test
     @Order(10)
+    @Tag("gate")
     void createWlsImgUsingWdt() throws Exception {
 
         String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
@@ -360,6 +371,7 @@ class ITImagetool extends BaseTest {
      */
     @Test
     @Order(11)
+    @Tag("nightly")
     void createFmwImgFullInternetAccess() throws Exception {
         String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
         logTestBegin(testMethodName);
@@ -395,6 +407,7 @@ class ITImagetool extends BaseTest {
      */
     @Test
     @Order(12)
+    @Tag("nightly")
     void createFmwImgNonDefault() throws Exception {
         String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
         logTestBegin(testMethodName);
@@ -434,6 +447,7 @@ class ITImagetool extends BaseTest {
      */
     @Test
     @Order(13)
+    @Tag("nightly")
     void testDCreateJRFDomainImgUsingWDT() throws Exception {
         String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
         logTestBegin(testMethodName);
@@ -499,6 +513,7 @@ class ITImagetool extends BaseTest {
      */
     @Test
     @Order(14)
+    @Tag("nightly")
     void createRestricedJrfDomainImgUsingWdt() throws Exception {
         String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
         logTestBegin(testMethodName);
@@ -551,6 +566,7 @@ class ITImagetool extends BaseTest {
      */
     @Test
     @Order(15)
+    @Tag("nightly")
     void createWlsImgUsingMultiModels() throws Exception {
         String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
         logTestBegin(testMethodName);
@@ -609,6 +625,7 @@ class ITImagetool extends BaseTest {
      */
     @Test
     @Order(16)
+    @Tag("nightly")
     void createWLSImgWithAdditionalBuildCommands() throws Exception {
         String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
         logTestBegin(testMethodName);


### PR DESCRIPTION
Separated tests by tag, nightly and gate.  Gate tests should run for every PR and gate merges to master.  Nightly tests will run all system tests once every weekday.  

Also, for branches with documentation ONLY checkins. the commit keyword [skip-ci] can be used to omit the running of tests.  This is intended to be used for branches where documentation will be merged just before the release.  Currently, each branch merge requires a merge from master, and a full system test run.  To create a release with 3 new documentation branches takes ~5 hours, today.