### PR TITLE
fixed issue preventing update image when doing wdtModelOnly

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -67,7 +67,7 @@ public class UpdateImage extends CommonOptions implements Callable<CommandRespon
             }
             dockerfileOptions.setOracleHome(oracleHome);
 
-            if (wdtOptions.isUsingWdt()) {
+            if (wdtOptions.isUsingWdt() && !wdtOptions.modelOnly()) {
                 String domainHome = baseImageProperties.getProperty("DOMAIN_HOME", null);
                 if (domainHome == null && wdtOperation == WdtOperation.UPDATE) {
                     return new CommandResponse(-1, "IMG-0071", fromImage);

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/WdtOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/WdtOptions.java
@@ -36,6 +36,15 @@ public class WdtOptions {
     }
 
     /**
+     * Return true if the user specified the wdtModelOnly option, and
+     * WDT should not run a create or update script.
+     * @return true if the WDT script should not run during the build.
+     */
+    boolean modelOnly() {
+        return wdtModelOnly;
+    }
+
+    /**
      * Checks whether the user requested a domain to be created with WDT.
      * If so,  creates required file links to pass the model, archive, variables file to build process.
      *


### PR DESCRIPTION
When running updateImage with wdtModelOnly, the check for an existing domain in the base image should not be called.