### PR TITLE
remove github deploy in favor of push to OCI for SNAPSHOT installer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,5 +90,18 @@ pipeline {
                 }
             }
         }
+        stage ('Save Nightly Installer'){
+            when {
+                allOf {
+                    triggeredBy 'TimerTrigger'
+                    branch "master"
+                }
+            }
+            steps {
+                sh '''
+                    oci os object put --namespace=weblogick8s --bucket-name=wko-system-test-files --config-file=/dev/null --auth=instance_principal --force --file=installer/target/imagetool.zip --name=imagetool-master.zip
+                '''
+            }
+        }
      }
 }

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -13,16 +13,4 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-<!--  <build>-->
-<!--    <plugins>-->
-<!--      <plugin>-->
-<!--        <groupId>org.apache.maven.plugins</groupId>-->
-<!--        <artifactId>maven-deploy-plugin</artifactId>-->
-<!--        <version>3.0.0-M1</version>-->
-<!--        <configuration>-->
-<!--          <skip>true</skip>-->
-<!--        </configuration>-->
-<!--      </plugin>-->
-<!--    </plugins>-->
-<!--  </build>-->
 </project>

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -69,13 +69,6 @@
                     </execution>
                 </executions>
             </plugin>
-<!--            <plugin>-->
-<!--                <groupId>org.apache.maven.plugins</groupId>-->
-<!--                <artifactId>maven-deploy-plugin</artifactId>-->
-<!--                <configuration>-->
-<!--                    <skip>false</skip>-->
-<!--                </configuration>-->
-<!--            </plugin>-->
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,14 +30,6 @@
         <tag>HEAD</tag>
     </scm>
 
-<!--    <distributionManagement>-->
-<!--        <repository>-->
-<!--            <id>github</id>-->
-<!--            <name>GitHub packages</name>-->
-<!--            <url>https://maven.pkg.github.com/oracle</url>-->
-<!--        </repository>-->
-<!--    </distributionManagement>-->
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -106,14 +98,6 @@
     <build>
         <pluginManagement>
             <plugins>
-<!--                <plugin>-->
-<!--                    <groupId>org.apache.maven.plugins</groupId>-->
-<!--                    <artifactId>maven-deploy-plugin</artifactId>-->
-<!--                    <version>3.0.0-M1</version>-->
-<!--                    <configuration>-->
-<!--                        <skip>true</skip>-->
-<!--                    </configuration>-->
-<!--                </plugin>-->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
GitHub did not provide URL interface that the WKO system tests could consume.  For now, abandoning maven deploy in favor of OCI object store for the WKO system test artifacts.