### PR TITLE
added WLS installer types for the slim and development installers

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
@@ -10,6 +10,8 @@ import java.util.List;
  * Supported Fusion Middleware installer sets.
  */
 public enum FmwInstallerType {
+    WLSSLIM(InstallerType.WLSSLIM),
+    WLSDEV(InstallerType.WLSDEV),
     WLS(InstallerType.WLS), //WebLogic Server
     FMW(InstallerType.FMW), //WebLogic Server Infrastructure (JRF)
     OSB(InstallerType.FMW, InstallerType.OSB),  //Service Bus

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/InstallerType.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/InstallerType.java
@@ -9,6 +9,8 @@ package com.oracle.weblogic.imagetool.installer;
  */
 public enum InstallerType {
 
+    WLSDEV("wlsdev"),
+    WLSSLIM("wlsslim"),
     WLS("wls"),
     FMW("fmw"),
     SOA("soa"),

--- a/site/create-image.md
+++ b/site/create-image.md
@@ -31,7 +31,7 @@ Usage: imagetool create [OPTIONS]
 | `--patches` | Comma separated list of patch IDs. Example: `12345678,87654321`  |   |
 | `--pull` | Always attempt to pull a newer version of base images during the build.  |   |
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0`  |   |
-| `--type` | Installer type. Supported values: `WLS`, `FMW`, `IDM`, `OSB`, `OUD_WLS`, `SOA_OSB`, `WCP`, `OAM`, `OIG`, `OUD`, `SOA`, `WCC`, `WCS`, `WCP`  | `WLS`  |
+| `--type` | Installer type. Supported values: `WLS`, `WLSDEV`, `WLSSLIM`, `FMW`, `IDM`, `OSB`, `OUD_WLS`, `SOA_OSB`, `WCP`, `OAM`, `OIG`, `OUD`, `SOA`, `WCC`, `WCS`, `WCP`  | `WLS`  |
 | `--user` | Oracle support email ID.  |   |
 | `--version` | Installer version. | `12.2.1.3.0`  |
 | `--wdtArchive` | Path to the WDT archive file used by the WDT model.  |   |

--- a/site/rebase-image.md
+++ b/site/rebase-image.md
@@ -35,7 +35,7 @@ Usage: imagetool rebase [OPTIONS]
 | `--sourceImage` | (Required) Source Image containing the WebLogic domain. |   |
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0`  |   |
 | `--targetImage` | Docker image to extend for the domain's new image. |   |
-| `--type` | Installer type. Supported values: `WLS`, `FMW`, `IDM`, `OSB`, `OUD_WLS`, `SOA_OSB`, `WCP`, `OAM`, `OIG`, `OUD`, `SOA`, `WCC`, `WCS`, `WCP`  | `WLS`  |
+| `--type` | Installer type. Supported values: `WLS`, `WLSDEV`, `WLSSLIM`, `FMW`, `IDM`, `OSB`, `OUD_WLS`, `SOA_OSB`, `WCP`, `OAM`, `OIG`, `OUD`, `SOA`, `WCC`, `WCS`, `WCP`  | `WLS`  |
 | `--user` | Your Oracle support email ID.  |   |
 | `--version` | Installer version. | `12.2.1.3.0`  |
 


### PR DESCRIPTION
Allow the user to have Slim, Dev, and normal WLS installers in their cache for a given version of WLS.