### PR TITLE
default chown to oracle:root 

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -487,7 +487,7 @@ public abstract class CommonOptions {
         names = {"--chown"},
         split = ":",
         description = "userid:groupid for JDK/Middleware installs and patches. Default: ${DEFAULT-VALUE}.",
-        defaultValue = "oracle:oracle"
+        defaultValue = "oracle:root"
     )
     private String[] osUserAndGroup;
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
@@ -80,7 +80,7 @@ public class DockerfileOptions {
         skipJavaInstall = false;
 
         username = "oracle";
-        groupname = "oracle";
+        groupname = "root";
 
         javaHome = DEFAULT_JAVA_HOME;
         oracleHome = DEFAULT_ORACLE_HOME;

--- a/imagetool/src/main/resources/docker-files/Update_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Update_Image.mustache
@@ -100,7 +100,7 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 USER {{userid}}
 
 {{#isOpatchPatchingEnabled}}
-    COPY --chown=oracle:oracle {{{opatchFileName}}} {{{tempDir}}}/opatch/
+    COPY --chown={{userid}}:{{groupid}} {{{opatchFileName}}} {{{tempDir}}}/opatch/
     RUN cd {{{tempDir}}}/opatch \
     && {{{java_home}}}/bin/jar -xf {{{tempDir}}}/opatch/{{{opatchFileName}}} \
     && {{{java_home}}}/bin/java -jar {{{tempDir}}}/opatch/6880880/opatch_generic.jar -silent -ignoreSysPrereqs -force -novalidation oracle_home={{{oracle_home}}} \


### PR DESCRIPTION
Change default for chown to oracle:root instead of oracle:oracle in order to match published Docker images for WebLogic Server.