### PR TITLE
during updateImage, detect fromImage user and group setting on Oracle Home

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -79,6 +79,12 @@ public class UpdateImage extends CommonOptions implements Callable<CommandRespon
 
             String opatchVersion = baseImageProperties.getProperty("OPATCH_VERSION");
 
+            String baseImageUsr = baseImageProperties.getProperty("ORACLE_HOME_USER");
+            String baseImageGrp = baseImageProperties.getProperty("ORACLE_HOME_GROUP");
+            if (!dockerfileOptions.userid().equals(baseImageUsr) || !dockerfileOptions.groupid().equals(baseImageGrp)) {
+                return new CommandResponse(-1, "IMG-0087", fromImage, baseImageUsr, baseImageGrp);
+            }
+
             String lsinventoryText = null;
 
             if (applyingPatches()) {

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -85,3 +85,4 @@ IMG-0083=Version {0} for patch ID {1} was not found in the available versions: {
 IMG-0084=No recommended patches found for {0}
 IMG-0085=The recommended ADR patch was skipped for the WLS installer, use --patch {0} to apply this patch
 IMG-0086=Failed to find patch number [[brightred: {0}]] on Oracle servers, verify the patch number is correct using My Oracle Support.
+IMG-0087=The Oracle Home directory in --fromImage={0} has an owner and group of {1}:{2}.  You must update the image with the same user and group setting from when it was created. Example: --chown={1}:{2}

--- a/imagetool/src/main/resources/probe-env/test-update-env.sh
+++ b/imagetool/src/main/resources/probe-env/test-update-env.sh
@@ -43,6 +43,9 @@ if [[ -n "$ORACLE_HOME" ]]; then
   echo OPATCH_VERSION="$("$ORACLE_HOME"/OPatch/opatch version 2> /dev/null | grep -oE -m 1 '([[:digit:]\.]+)')"
   "$ORACLE_HOME"/OPatch/opatch lsinventory > /tmp/lsout 2> /dev/null
 
+  echo ORACLE_HOME_USER="$(stat -c '%U' "$ORACLE_HOME")"
+  echo ORACLE_HOME_GROUP="$(stat -c '%G' "$ORACLE_HOME")"
+
   if [[  -f "/tmp/lsout" ]]; then
     echo LSINV_TEXT="$(base64 -w 0 /tmp/lsout)"
   fi


### PR DESCRIPTION
When updating an image with UPDATE, if the chown of the update is not the same as what was used during the create, the update will fail with a directory permissions error.  This change detects the chown value that was used during the CREATE, and exits with a error and a clean description of what the user needs to do to get the update to work.