### PR TITLE
Fixfinalcopy

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
@@ -318,7 +318,7 @@ public class DockerfileOptions {
      * Check to see if WDT model home is not under WDT home.
      * @return true|false
      */
-    public boolean isWdtModelHomeUnderWdtHome() {
+    public boolean isNotWdtModelHomeUnderWdtHome() {
         return !wdtModelHome.startsWith(wdtHome + "/");
     }
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
@@ -318,8 +318,8 @@ public class DockerfileOptions {
      * Check to see if WDT model home is not under WDT home.
      * @return true|false
      */
-    public boolean isNotWdtModelHomeUnderWdtHome() {
-        return !wdtModelHome.startsWith(wdtHome + "/");
+    public boolean isWdtModelHomeOutsideWdtHome() {
+        return !wdtModelHome.startsWith(wdtHome + File.separator);
     }
 
     public boolean isWdtValidateEnabled() {

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
@@ -314,6 +314,14 @@ public class DockerfileOptions {
         return wdtModelHome;
     }
 
+    /**
+     * Check to see if WDT model home is not under WDT home.
+     * @return true|false
+     */
+    public boolean isWdtModelHomeUnderWdtHome() {
+        return !wdtModelHome.startsWith(wdtHome + "/");
+    }
+
     public boolean isWdtValidateEnabled() {
         return isWdtEnabled() && modelOnly() && (!wdtModelList.isEmpty() || !wdtArchiveList.isEmpty());
     }

--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -251,9 +251,9 @@ COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle
         && mkdir -p {{{wdt_model_home}}} \
         && chmod g+w {{{wdt_model_home}}}
         COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
-        {{#isWdtModelHomeUnderWdtHome}}
+        {{#isNotWdtModelHomeUnderWdtHome}}
             COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_model_home}} {{wdt_model_home}}/
-        {{/isWdtModelHomeUnderWdtHome}}
+        {{/isNotWdtModelHomeUnderWdtHome}}
     {{/modelOnly}}
     {{^modelOnly}}
         COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{{domain_home}}} {{{domain_home}}}/

--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -251,9 +251,9 @@ COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle
         && mkdir -p {{{wdt_model_home}}} \
         && chmod g+w {{{wdt_model_home}}}
         COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
-        {{#isNotWdtModelHomeUnderWdtHome}}
+        {{#isWdtModelHomeOutsideWdtHome}}
             COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_model_home}} {{wdt_model_home}}/
-        {{/isNotWdtModelHomeUnderWdtHome}}
+        {{/isWdtModelHomeOutsideWdtHome}}
     {{/modelOnly}}
     {{^modelOnly}}
         COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{{domain_home}}} {{{domain_home}}}/

--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -247,11 +247,13 @@ COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle
         RUN DOMAIN_PARENT=$(dirname {{{domain_home}}}) \
         && mkdir -p $DOMAIN_PARENT \
         && chown {{userid}}:{{groupid}} $DOMAIN_PARENT \
-        && chmod g+w $DOMAIN_PARENT
-        COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
-        RUN mkdir -p {{{wdt_model_home}}} \
+        && chmod g+w $DOMAIN_PARENT \
+        && mkdir -p {{{wdt_model_home}}} \
         && chmod g+w {{{wdt_model_home}}}
-        COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_model_home}} {{wdt_model_home}}/
+        COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
+        {{#isWdtModelHomeUnderWdtHome}}
+            COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_model_home}} {{wdt_model_home}}/
+        {{/isWdtModelHomeUnderWdtHome}}
     {{/modelOnly}}
     {{^modelOnly}}
         COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{{domain_home}}} {{{domain_home}}}/

--- a/imagetool/src/main/resources/docker-files/Update_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Update_Image.mustache
@@ -124,9 +124,9 @@ USER {{userid}}
         && mkdir -p {{{wdt_model_home}}} \
         && chmod g+w {{{wdt_model_home}}}
         COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
-        {{#isWdtModelHomeUnderWdtHome}}
+        {{#isNotWdtModelHomeUnderWdtHome}}
             COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_model_home}} {{wdt_model_home}}/
-        {{/isWdtModelHomeUnderWdtHome}}
+        {{/isNotWdtModelHomeUnderWdtHome}}
     {{/modelOnly}}
     {{^modelOnly}}
         COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{{domain_home}}} {{{domain_home}}}/

--- a/imagetool/src/main/resources/docker-files/Update_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Update_Image.mustache
@@ -124,9 +124,9 @@ USER {{userid}}
         && mkdir -p {{{wdt_model_home}}} \
         && chmod g+w {{{wdt_model_home}}}
         COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
-        {{#isNotWdtModelHomeUnderWdtHome}}
+        {{#isWdtModelHomeOutsideWdtHome}}
             COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_model_home}} {{wdt_model_home}}/
-        {{/isNotWdtModelHomeUnderWdtHome}}
+        {{/isWdtModelHomeOutsideWdtHome}}
     {{/modelOnly}}
     {{^modelOnly}}
         COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{{domain_home}}} {{{domain_home}}}/

--- a/imagetool/src/main/resources/docker-files/Update_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Update_Image.mustache
@@ -120,11 +120,13 @@ USER {{userid}}
         RUN DOMAIN_PARENT=$(dirname {{{domain_home}}}) \
         && mkdir -p $DOMAIN_PARENT \
         && chown {{userid}}:{{groupid}} $DOMAIN_PARENT \
-        && chmod g+w $DOMAIN_PARENT
-        COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
-        RUN mkdir -p {{{wdt_model_home}}} \
+        && chmod g+w $DOMAIN_PARENT \
+        && mkdir -p {{{wdt_model_home}}} \
         && chmod g+w {{{wdt_model_home}}}
-        COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_model_home}} {{wdt_model_home}}/
+        COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
+        {{#isWdtModelHomeUnderWdtHome}}
+            COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_model_home}} {{wdt_model_home}}/
+        {{/isWdtModelHomeUnderWdtHome}}
     {{/modelOnly}}
     {{^modelOnly}}
         COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{{domain_home}}} {{{domain_home}}}/


### PR DESCRIPTION
This change is trying to avoid the problem where an additional COPY step is added to the end of the Dockerfile that causes the Docker build to fail with missing layer error.  This only fails on some versions of Docker (and perhaps only some versions of host OS).  It looks like a docker bug that we can workaround by optimizing the final build step copy logic to not copy the WDT home again if it has already been copied (under WDT home).  It is unclear why this works.