### PR TITLE
Opatch patch detect

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cachestore/OPatchFile.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cachestore/OPatchFile.java
@@ -76,6 +76,19 @@ public class OPatchFile extends PatchFile {
         return latestVersion;
     }
 
+    /**
+     * Return true if the patchId matches any known OPatch bug numbers.
+     *
+     * @param patchId the patch ID to test
+     * @return true if and only if the patchId matches an OPatch bug number.
+     */
+    public static boolean isOPatchPatch(String patchId) {
+        if (DEFAULT_BUG_NUM.equals(patchId)) {
+            return true;
+        }
+        return patchId != null && patchId.startsWith(DEFAULT_BUG_NUM + CacheStore.CACHE_KEY_SEPARATOR);
+    }
+
     @Override
     public String resolve(CacheStore cacheStore) throws IOException {
         try {

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -295,7 +295,7 @@ public abstract class CommonOptions {
         // add user-provided patch list to any patches that were found for latestPsu or recommendedPatches
         for (String patchId : patches) {
             // if user mistakenly added the OPatch patch to the WLS patch list, skip it
-            if (OPatchFile.DEFAULT_BUG_NUM.equals(patchId)) {
+            if (OPatchFile.isOPatchPatch(patchId)) {
                 continue;
             }
             // if patch ID was provided as bugnumber_version, split the bugnumber and version strings

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/cachestore/OPatchFileTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/cachestore/OPatchFileTest.java
@@ -6,6 +6,7 @@ package com.oracle.weblogic.imagetool.cachestore;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("unit")
@@ -14,5 +15,9 @@ public class OPatchFileTest {
     void opatchPatchIdTest() {
         assertTrue(OPatchFile.isOPatchPatch("28186730"), "OPatch bug number");
         assertTrue(OPatchFile.isOPatchPatch("28186730_13.9.4.2.4"), "OPatch bug number with version");
+        assertTrue(OPatchFile.isOPatchPatch("28186730_1"), "OPatch bug number with separator");
+
+        assertFalse(OPatchFile.isOPatchPatch("28186731"), "Should not match");
+        assertFalse(OPatchFile.isOPatchPatch("281867301"), "OPatch bug number with additional number");
     }
 }

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/cachestore/OPatchFileTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/cachestore/OPatchFileTest.java
@@ -1,0 +1,18 @@
+// Copyright (c) 2020, Oracle Corporation and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.weblogic.imagetool.cachestore;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("unit")
+public class OPatchFileTest {
+    @Test
+    void opatchPatchIdTest() {
+        assertTrue(OPatchFile.isOPatchPatch("28186730"), "OPatch bug number");
+        assertTrue(OPatchFile.isOPatchPatch("28186730_13.9.4.2.4"), "OPatch bug number with version");
+    }
+}


### PR DESCRIPTION
Detection of OPatch patches was limited to the bug number.  If the user provided the bug number plus the version, it circumvented the check.  28186730 and 28186730_* should now be skipped. Fixes #219 