### PR TITLE
add feature to enable strict ordering for patching

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -326,6 +326,9 @@ public abstract class CommonOptions {
             if (patchLocation != null && !Utils.isEmptyString(patchLocation)) {
                 File cacheFile = new File(patchLocation);
                 try {
+                    if (patch.fileName() == null) {
+                        patch.fileName(cacheFile.getName());
+                    }
                     Files.copy(Paths.get(patchLocation), Paths.get(patchesFolderName, cacheFile.getName()));
                 } catch (FileAlreadyExistsException ee) {
                     logger.warning("IMG-0077", patchFile.getKey());
@@ -335,7 +338,10 @@ public abstract class CommonOptions {
             }
         }
         if (!aruPatches.isEmpty()) {
-            dockerfileOptions.setPatchingEnabled();
+            dockerfileOptions
+                .setPatchingEnabled()
+                .setStrictPatchOrdering(strictPatchOrdering)
+                .setPatchList(aruPatches);
         }
         logger.exiting();
     }
@@ -521,6 +527,12 @@ public abstract class CommonOptions {
         description = "Whether to apply recommended patches from latest PSU."
     )
     boolean recommendedPatches = false;
+
+    @Option(
+        names = {"--strictPatchOrdering"},
+        description = "Use OPatch to apply patches one at a time."
+    )
+    boolean strictPatchOrdering = false;
 
     @Option(
         names = {"--patches"},

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
@@ -9,7 +9,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
+import com.oracle.weblogic.imagetool.aru.AruPatch;
 import com.oracle.weblogic.imagetool.cli.menu.PackageManagerType;
 import com.oracle.weblogic.imagetool.installer.MiddlewareInstall;
 import com.oracle.weblogic.imagetool.installer.MiddlewareInstallPackage;
@@ -36,6 +38,7 @@ public class DockerfileOptions {
     private boolean skipJavaInstall;
     private boolean isRebaseToTarget;
     private boolean isRebaseToNew;
+    private boolean strictPatchOrdering;
 
     private String javaInstaller;
     private String username;
@@ -51,6 +54,7 @@ public class DockerfileOptions {
     private String sourceImage;
     private String targetImage;
     private PackageManagerType pkgMgr;
+    private List<String> patchFilenames;
 
     // WDT values
     private String wdtHome;
@@ -792,6 +796,44 @@ public class DockerfileOptions {
             return Collections.emptyList();
         }
         return additionalBuildCommands.get(sectionName);
+    }
+
+    @SuppressWarnings("unused")
+    public boolean strictPatchOrdering() {
+        return strictPatchOrdering;
+    }
+
+    /**
+     * Set strict patch ordering to apply each patch one at a time, instead of
+     * in a single pass with OPatch.  This will slow down the patching process but
+     * is necessary for some patches.
+     *
+     * @param value true to enable strict ordering
+     * @return this
+     */
+    public DockerfileOptions setStrictPatchOrdering(boolean value) {
+        strictPatchOrdering = value;
+        return this;
+    }
+
+    /**
+     * Set patch file names to be used for OPatch.
+     * This list is only used when using strictPatchOrdering.
+     *
+     * @param patchList list of ARU Patches
+     * @return this
+     */
+    public DockerfileOptions setPatchList(List<AruPatch> patchList) {
+        patchFilenames = patchList.stream()
+            .map(AruPatch::fileName)
+            .collect(Collectors.toList());
+
+        return this;
+    }
+
+    @SuppressWarnings("unused")
+    public List<String> patches() {
+        return patchFilenames;
     }
 
     /**

--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -125,10 +125,20 @@ RUN cd {{{tempDir}}}/opatch \
 {{/isOpatchPatchingEnabled}}
 
 {{#isPatchingEnabled}}
-RUN {{{oracle_home}}}/OPatch/opatch napply -silent -oh {{{oracle_home}}} -phBaseDir {{{tempDir}}}/patches \
- && test $? -eq 0 \
- && {{{oracle_home}}}/OPatch/opatch util cleanup -silent -oh {{{oracle_home}}} \
- || (cat {{{oracle_home}}}/cfgtoollogs/opatch/opatch*.log && exit 1)
+    {{^strictPatchOrdering}}
+        # Apply all patches provided at the same time
+        RUN {{{oracle_home}}}/OPatch/opatch napply -silent -oh {{{oracle_home}}} -phBaseDir {{{tempDir}}}/patches \
+        && test $? -eq 0 \
+        && {{{oracle_home}}}/OPatch/opatch util cleanup -silent -oh {{{oracle_home}}} \
+        || (cat {{{oracle_home}}}/cfgtoollogs/opatch/opatch*.log && exit 1)
+    {{/strictPatchOrdering}}
+    {{#strictPatchOrdering}}
+        # Apply one patch at a time in the order they were specified
+        {{#patches}}
+            RUN {{{oracle_home}}}/OPatch/opatch apply -silent -oh {{{oracle_home}}} {{{tempDir}}}/patches/{{{.}}}
+        {{/patches}}
+        RUN {{{oracle_home}}}/OPatch/opatch util cleanup -silent -oh {{{oracle_home}}}
+    {{/strictPatchOrdering}}
 {{/isPatchingEnabled}}
 
 {{#afterFmwInstall}}

--- a/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
@@ -147,8 +147,20 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
         && {{{java_home}}}/bin/java -jar {{{tempDir}}}/opatch/6880880/opatch_generic.jar -silent -ignoreSysPrereqs -force -novalidation oracle_home={{{oracle_home}}}
     {{/isOpatchPatchingEnabled}}
     {{#isPatchingEnabled}}
-    RUN {{{oracle_home}}}/OPatch/opatch napply -silent -oh {{{oracle_home}}} -phBaseDir {{{tempDir}}}/patches \
-        && {{{oracle_home}}}/OPatch/opatch util cleanup -silent -oh {{{oracle_home}}}
+        {{^strictPatchOrdering}}
+            # Apply all patches provided at the same time
+            RUN {{{oracle_home}}}/OPatch/opatch napply -silent -oh {{{oracle_home}}} -phBaseDir {{{tempDir}}}/patches \
+            && test $? -eq 0 \
+            && {{{oracle_home}}}/OPatch/opatch util cleanup -silent -oh {{{oracle_home}}} \
+            || (cat {{{oracle_home}}}/cfgtoollogs/opatch/opatch*.log && exit 1)
+        {{/strictPatchOrdering}}
+        {{#strictPatchOrdering}}
+            # Apply one patch at a time in the order they were specified
+            {{#patches}}
+                RUN {{{oracle_home}}}/OPatch/opatch apply -silent -oh {{{oracle_home}}} {{{tempDir}}}/patches/{{{.}}}
+            {{/patches}}
+            RUN {{{oracle_home}}}/OPatch/opatch util cleanup -silent -oh {{{oracle_home}}}
+        {{/strictPatchOrdering}}
     {{/isPatchingEnabled}}
 
     {{#afterFmwInstall}}

--- a/imagetool/src/main/resources/docker-files/Update_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Update_Image.mustache
@@ -110,9 +110,20 @@ USER {{userid}}
 {{#isPatchingEnabled}}
     COPY --chown={{userid}}:{{groupid}} patches/* {{{tempDir}}}/patches/
 
-    RUN {{{oracle_home}}}/OPatch/opatch napply -silent -oh {{{oracle_home}}} -phBaseDir {{{tempDir}}}/patches \
-    && {{{oracle_home}}}/OPatch/opatch util cleanup -silent -oh {{{oracle_home}}} \
-    && rm -rf {{{tempDir}}}
+    {{^strictPatchOrdering}}
+        # Apply all patches provided at the same time
+        RUN {{{oracle_home}}}/OPatch/opatch napply -silent -oh {{{oracle_home}}} -phBaseDir {{{tempDir}}}/patches \
+        && test $? -eq 0 \
+        && {{{oracle_home}}}/OPatch/opatch util cleanup -silent -oh {{{oracle_home}}} \
+        || (cat {{{oracle_home}}}/cfgtoollogs/opatch/opatch*.log && exit 1)
+    {{/strictPatchOrdering}}
+    {{#strictPatchOrdering}}
+        # Apply one patch at a time in the order they were specified
+        {{#patches}}
+            RUN {{{oracle_home}}}/OPatch/opatch apply -silent -oh {{{oracle_home}}} {{{tempDir}}}/patches/{{{.}}}
+        {{/patches}}
+        RUN {{{oracle_home}}}/OPatch/opatch util cleanup -silent -oh {{{oracle_home}}}
+    {{/strictPatchOrdering}}
 {{/isPatchingEnabled}}
 
 {{#isWdtEnabled}}


### PR DESCRIPTION
Allow user to override the default behavior for OPatch patching in order to apply each patch one at a time.  The default behavior is to send all requested patches to OPatch and use napply to add them in a single pass.  Using the new feature --strictPatchOrdering changes the default behavior and uses OPatch apply (instead of napply) to add each patch one at a time. Fixes #201