### PR TITLE
Change uppercase stage name to lowercase

### DIFF
--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -4,7 +4,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 #
-FROM {{baseImage}} as OS_UPDATE
+FROM {{baseImage}} as os_update
 LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 USER root
 
@@ -48,7 +48,7 @@ RUN if [ -z "$(getent group {{groupid}})" ]; then hash groupadd &> /dev/null && 
 
 {{#installJava}}
 # Install Java
-FROM OS_UPDATE as JDK_BUILD
+FROM os_update as jdk_build
 LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
 ENV JAVA_HOME={{{java_home}}}
@@ -72,7 +72,7 @@ RUN tar xzf {{{tempDir}}}/{{java_pkg}} -C /u01 \
 {{/installJava}}
 
 # Install Middleware
-FROM OS_UPDATE as WLS_BUILD
+FROM os_update as wls_build
 LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
 ENV JAVA_HOME={{{java_home}}} \
@@ -88,7 +88,7 @@ RUN mkdir -p {{{oracle_home}}} \
  && chown {{userid}}:{{groupid}} {{orainv_dir}} \
  && chown {{userid}}:{{groupid}} {{{oracle_home}}}
 
-{{#installJava}}COPY --from=JDK_BUILD --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
+{{#installJava}}COPY --from=jdk_build --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
 {{/installJava}}
 
 {{#installPackages}}COPY --chown={{userid}}:{{groupid}} {{installerFilename}} {{responseFile.name}} {{{tempDir}}}/
@@ -136,7 +136,7 @@ RUN {{{oracle_home}}}/OPatch/opatch napply -silent -oh {{{oracle_home}}} -phBase
 {{/afterFmwInstall}}
 
 {{#isWdtEnabled}}
-    FROM WLS_BUILD as WDT_BUILD
+    FROM wls_build as wdt_build
     ARG WDT_ENCRYPTION_KEY
     LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
@@ -206,7 +206,7 @@ RUN {{{oracle_home}}}/OPatch/opatch napply -silent -oh {{{oracle_home}}} -phBase
 
 {{/isWdtEnabled}}
 
-FROM OS_UPDATE as FINAL_BUILD
+FROM os_update as final_build
 
 ARG ADMIN_NAME
 ARG ADMIN_HOST
@@ -231,15 +231,15 @@ ENV ORACLE_HOME={{{oracle_home}}} \
 LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
 {{#installJava}}
-    COPY --from=JDK_BUILD --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
+    COPY --from=jdk_build --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
 {{/installJava}}
 
-COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle_home}}}/
+COPY --from=wls_build --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle_home}}}/
 {{#copyOraInst}}
-    COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{inv_loc}}/oraInst.loc  {{inv_loc}}/oraInst.loc
+    COPY --from=wls_build --chown={{userid}}:{{groupid}} {{inv_loc}}/oraInst.loc  {{inv_loc}}/oraInst.loc
 {{/copyOraInst}}
 {{#copyOraInventoryDir}}
-    COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{orainv_dir}} {{orainv_dir}}/
+    COPY --from=wls_build --chown={{userid}}:{{groupid}} {{orainv_dir}} {{orainv_dir}}/
 {{/copyOraInventoryDir}}
 
 {{#isWdtEnabled}}
@@ -250,13 +250,13 @@ COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle
         && chmod g+w $DOMAIN_PARENT \
         && mkdir -p {{{wdt_model_home}}} \
         && chmod g+w {{{wdt_model_home}}}
-        COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
+        COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
         {{#isWdtModelHomeOutsideWdtHome}}
-            COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_model_home}} {{wdt_model_home}}/
+            COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{wdt_model_home}} {{wdt_model_home}}/
         {{/isWdtModelHomeOutsideWdtHome}}
     {{/modelOnly}}
     {{^modelOnly}}
-        COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{{domain_home}}} {{{domain_home}}}/
+        COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{{domain_home}}} {{{domain_home}}}/
         RUN chmod g+w {{{domain_home}}}
     {{/modelOnly}}
 {{/isWdtEnabled}}

--- a/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
@@ -6,8 +6,8 @@
 #
 
 {{#isRebaseToTarget}}
-FROM {{sourceImage}} as SOURCE_IMAGE
-FROM {{targetImage}} as FINAL_BUILD
+FROM {{sourceImage}} as source_image
+FROM {{targetImage}} as final_build
 ARG ADMIN_PORT
 ARG MANAGED_SERVER_PORT
 
@@ -18,8 +18,8 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
 {{/isRebaseToTarget}}
 {{#isRebaseToNew}}
-    FROM {{sourceImage}} as SOURCE_IMAGE
-    FROM {{baseImage}} as OS_UPDATE
+    FROM {{sourceImage}} as source_image
+    FROM {{baseImage}} as os_update
     ARG ADMIN_PORT
     ARG MANAGED_SERVER_PORT
 
@@ -70,7 +70,7 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
     {{#installJava}}
         # Install Java
-        FROM OS_UPDATE as JDK_BUILD
+        FROM os_update as jdk_build
         LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
         ENV JAVA_HOME={{{java_home}}}
@@ -93,7 +93,7 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
         {{/afterJdkInstall}}
     {{/installJava}}
 
-    FROM OS_UPDATE as WLS_BUILD
+    FROM os_update as wls_build
     # Install middleware
     LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
@@ -111,7 +111,7 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
     && chown {{userid}}:{{groupid}} {{{oracle_home}}}
 
     {{#installJava}}
-        COPY --from=JDK_BUILD --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
+        COPY --from=jdk_build --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
     {{/installJava}}
 
     {{#installPackages}}COPY --chown={{userid}}:{{groupid}} {{installerFilename}} {{responseFile.name}} {{{tempDir}}}/
@@ -156,7 +156,7 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
     {{/afterFmwInstall}}
 
 
-    FROM OS_UPDATE as FINAL_BUILD
+    FROM os_update as final_build
 
     ARG ADMIN_NAME
     ARG ADMIN_HOST
@@ -173,21 +173,21 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
     LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
     {{#installJava}}
-        COPY --from=JDK_BUILD --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
+        COPY --from=jdk_build --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
     {{/installJava}}
 
-    COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle_home}}}/
+    COPY --from=wls_build --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle_home}}}/
     {{#copyOraInst}}
-        COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{inv_loc}}/oraInst.loc  {{inv_loc}}/oraInst.loc
+        COPY --from=wls_build --chown={{userid}}:{{groupid}} {{inv_loc}}/oraInst.loc  {{inv_loc}}/oraInst.loc
     {{/copyOraInst}}
     {{#copyOraInventoryDir}}
-        COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{orainv_dir}} {{orainv_dir}}/
+        COPY --from=wls_build --chown={{userid}}:{{groupid}} {{orainv_dir}} {{orainv_dir}}/
     {{/copyOraInventoryDir}}
 {{/isRebaseToNew}}
 
 USER {{userid}}
 RUN mkdir -p {{domain_home}}
-COPY --from=SOURCE_IMAGE --chown={{userid}}:{{groupid}} {{domain_home}} {{domain_home}}/
+COPY --from=source_image --chown={{userid}}:{{groupid}} {{domain_home}} {{domain_home}}/
 RUN chmod g+w {{{domain_home}}}
 
 EXPOSE $ADMIN_PORT $MANAGED_SERVER_PORT

--- a/imagetool/src/main/resources/docker-files/Update_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Update_Image.mustache
@@ -5,7 +5,7 @@
 #
 #
 {{#isWdtEnabled}}
-    FROM {{baseImage}} as WDT_BUILD
+    FROM {{baseImage}} as wdt_build
     ARG WDT_ENCRYPTION_KEY
     LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
@@ -80,7 +80,7 @@
     {{/afterWdtCommand}}
 {{/isWdtEnabled}}
 
-FROM {{baseImage}} as FINAL_BUILD
+FROM {{baseImage}} as final_build
 USER root
 
 ENV OPATCH_NO_FUSER=true
@@ -123,13 +123,13 @@ USER {{userid}}
         && chmod g+w $DOMAIN_PARENT \
         && mkdir -p {{{wdt_model_home}}} \
         && chmod g+w {{{wdt_model_home}}}
-        COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
+        COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
         {{#isWdtModelHomeOutsideWdtHome}}
-            COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_model_home}} {{wdt_model_home}}/
+            COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{wdt_model_home}} {{wdt_model_home}}/
         {{/isWdtModelHomeOutsideWdtHome}}
     {{/modelOnly}}
     {{^modelOnly}}
-        COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{{domain_home}}} {{{domain_home}}}/
+        COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{{domain_home}}} {{{domain_home}}}/
         RUN chmod g+w {{{domain_home}}}
     {{/modelOnly}}
 {{/isWdtEnabled}}

--- a/site/create-image.md
+++ b/site/create-image.md
@@ -57,12 +57,12 @@ The input for this parameter is a simple text file that contains one or more of 
 
 | Section | Build Stage | Timing |
 | --- | --- | --- |
-| `before-jdk-install` | Intermediate (JDK_BUILD) | Before the JDK is installed. |
-| `after-jdk-install` | Intermediate (JDK_BUILD) | After the JDK is installed. |
-| `before-fmw-install` | Intermediate (WLS_BUILD) | Before the Oracle Home is created. |
-| `after-fmw-install` | Intermediate (WLS_BUILD) | After all of the Oracle middleware installers are finished. |
-| `before-wdt-command` | Intermediate (WDT_BUILD) | Before WDT is installed. |
-| `after-wdt-command` | Intermediate (WDT_BUILD) | After WDT domain creation/update is complete. |
+| `before-jdk-install` | Intermediate (jdk_build) | Before the JDK is installed. |
+| `after-jdk-install` | Intermediate (jdk_build) | After the JDK is installed. |
+| `before-fmw-install` | Intermediate (wls_build) | Before the Oracle Home is created. |
+| `after-fmw-install` | Intermediate (wls_build) | After all of the Oracle middleware installers are finished. |
+| `before-wdt-command` | Intermediate (wdt_build) | Before WDT is installed. |
+| `after-wdt-command` | Intermediate (wdt_build) | After WDT domain creation/update is complete. |
 | `final-build-commands` | Final image | After all Image Tool actions are complete, and just before the Docker image is finalized. |
 
 NOTE: Changes made in intermediate stages may not be carried forward to the final image unless copied manually.  

--- a/site/rebase-image.md
+++ b/site/rebase-image.md
@@ -48,10 +48,10 @@ The input for this parameter is a simple text file that contains one or more of 
 
 | Section | Build Stage | Timing |
 | --- | --- | --- |
-| `before-jdk-install` | Intermediate (JDK_BUILD) | Before the JDK is installed. |
-| `after-jdk-install` | Intermediate (JDK_BUILD) | After the JDK is installed. |
-| `before-fmw-install` | Intermediate (WLS_BUILD) | Before the Oracle Home is created. |
-| `after-fmw-install` | Intermediate (WLS_BUILD) | After all of the Oracle middleware installers are finished. |
+| `before-jdk-install` | Intermediate (jdk_build) | Before the JDK is installed. |
+| `after-jdk-install` | Intermediate (jdk_build) | After the JDK is installed. |
+| `before-fmw-install` | Intermediate (wls_build) | Before the Oracle Home is created. |
+| `after-fmw-install` | Intermediate (wls_build) | After all of the Oracle middleware installers are finished. |
 | `final-build-commands` | Final image | After all Image Tool actions are complete, and just before the Docker image is finalized. |
 
 NOTE: Changes made in intermediate stages may not be carried forward to the final image unless copied manually.  

--- a/site/update-image.md
+++ b/site/update-image.md
@@ -65,8 +65,8 @@ The input for this parameter is a simple text file that contains one or more of 
 
 | Section | Build Stage | Timing |
 | --- | --- | --- |
-| `before-wdt-command` | Intermediate (WDT_BUILD) | Before WDT is installed. |
-| `after-wdt-command` | Intermediate (WDT_BUILD) | After WDT domain creation/update is complete. |
+| `before-wdt-command` | Intermediate (wdt_build) | Before WDT is installed. |
+| `after-wdt-command` | Intermediate (wdt_build) | After WDT domain creation/update is complete. |
 | `final-build-commands` | Final image | After all Image Tool actions are complete, and just before the Docker image is finalized. |
 
 NOTE: Changes made in intermediate stages may not be carried forward to the final image unless copied manually.  

--- a/tests/src/test/resources/wdt/multi-sections.txt
+++ b/tests/src/test/resources/wdt/multi-sections.txt
@@ -21,5 +21,5 @@ LABEL after-wdt-command="afterWDTCommand"
 
 [final-build-commands]
 LABEL final-build-commands="finalBuildCommands"
-COPY --from=JDK_BUILD --chown=oracle:oracle /u01/beforeJDKInstall.txt /u01/afterJDKInstall.txt /u01/jdk/
-COPY --from=WLS_BUILD --chown=oracle:oracle /u01/beforeFMWInstall.txt /u01/afterFMWInstall.txt /u01/oracle/
+COPY --from=jdk_build --chown=oracle:oracle /u01/beforeJDKInstall.txt /u01/afterJDKInstall.txt /u01/jdk/
+COPY --from=wls_build --chown=oracle:oracle /u01/beforeFMWInstall.txt /u01/afterFMWInstall.txt /u01/oracle/


### PR DESCRIPTION
I got error during running commands via docker `19.03.13`:
```shell
$sh imagetool.sh create --tag=weblogic:12.2.1.4 --type=wls --version=12.2.1.4.0 --jdkVersion=8u271
#1 transferring context: 2B done
#1 DONE 0.1s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 2.90kB 0.0s done
#2 DONE 0.1s
failed to solve with frontend dockerfile.v0: failed to create LLB definition: failed to parse stage name "OS_UPDATE": invalid reference format: repository name must be lowercase
```

I found there are two related issues:
https://github.com/oracle/weblogic-image-tool/issues/158
https://github.com/oracle/weblogic-image-tool/issues/71

And there is a workaround:
1. run command skipping cleanup
```shell
$ sh imagetool.sh create --tag=weblogic:12.2.1.4 --type=wls --version=12.2.1.4.0 --jdkVersion=8u271 --skipcleanup
imagetool.sh: 47: Bad substitution
[INFO   ] Image Tool build ID: 63fd2683-13ae-4e23-a01e-36e86c1573a5
[INFO   ] Temporary directory used for docker build context: /home/bamboo/wlsimgbuilder_temp1378067397118749720
[INFO   ] Copying /home/bamboo/wls/jdk-8u271-linux-x64.tar.gz to build context folder.
[INFO   ] Using middleware installers (wls) version 12.2.1.4.0
[INFO   ] Copying /home/bamboo/wls/fmw_12.2.1.4.0_wls_Disk1_1of1.zip to build context folder.
[INFO   ] docker cmd = docker build --no-cache --force-rm --tag weblogic:12.2.1.4 /home/bamboo/wlsimgbuilder_temp1378067397118749720
```
2. Changed the uppercase stage name to lowercase in /home/bamboo/wlsimgbuilder_temp1378067397118749720/Dockerfile
3. Run the docker command
```shell
$ docker build --no-cache --force-rm --tag weblogic:12.2.1.4 /home/bamboo/wlsimgbuilder_temp1378067397118749720
[+] Building 113.1s (14/17)
 => [internal] load .dockerignore                                                                                  0.0s
[+] Building 154.5s (18/18) FINISHED
 => [internal] load .dockerignore                                                                                  0.0s
 => => transferring context: 2B                                                                                    0.0s
 => [internal] load build definition from Dockerfile                                                               0.0s
 => => transferring dockerfile: 2.90kB                                                                             0.0s
 => [internal] load metadata for docker.io/library/oraclelinux:7-slim                                              3.1s
 => CACHED [os_update 1/3] FROM docker.io/library/oraclelinux:7-slim@sha256:bc574a4cdb83591874e5c6ce5d9fa46849457  0.0s
 => [internal] load build context                                                                                  7.6s
 => => transferring context: 1.01GB                                                                                7.6s
 => [os_update 2/3] RUN yum -y --downloaddir=/tmp/imagetool install gzip tar unzip libaio  && yum -y --downloadd  21.7s
 => [os_update 3/3] RUN if [ -z "$(getent group oracle)" ]; then hash groupadd &> /dev/null && groupadd oracle ||  0.5s
 => [wls_build 1/5] RUN mkdir -p /u01/oracle  && mkdir -p /u01/oracle/oraInventory  && chown oracle:oracle /u01/o  0.9s
 => [jdk_build 1/2] COPY --chown=oracle:oracle jdk-8u271-linux-x64.tar.gz /tmp/imagetool/                          0.6s
 => [jdk_build 2/2] RUN tar xzf /tmp/imagetool/jdk-8u271-linux-x64.tar.gz -C /u01  && $(test -d /u01/jdk* && mv /  3.8s
 => [final_build 1/3] COPY --from=jdk_build --chown=oracle:oracle /u01/jdk /u01/jdk/                               1.4s
 => [wls_build 2/5] COPY --from=jdk_build --chown=oracle:oracle /u01/jdk /u01/jdk/                                 1.4s
 => [wls_build 3/5] COPY --chown=oracle:oracle fmw_12.2.1.4.0_wls_Disk1_1of1.zip wls.rsp /tmp/imagetool/           2.4s
 => [wls_build 4/5] COPY --chown=oracle:oracle oraInst.loc /u01/oracle/                                            0.0s
 => [wls_build 5/5] RUN echo "INSTALLING MIDDLEWARE"  && echo "INSTALLING wls"  && unzip -q /tmp/imagetool/fmw_  103.1s
 => [final_build 2/3] COPY --from=wls_build --chown=oracle:oracle /u01/oracle /u01/oracle/                         6.8s
 => [final_build 3/3] WORKDIR /u01/oracle                                                                          0.1s
 => exporting to image                                                                                             4.8s
 => => exporting layers                                                                                            4.8s
 => => writing image sha256:d9d70b6e7090d828b91aef4c8f9c9c05245782ad843bf23e181cc43ef2b9a99d                       0.0s
 => => naming to docker.io/library/weblogic:12.2.1.4
```

I checkout the source code and changed the uppercase stage name, built a new imagetool, it worked fine.
