### PR TITLE
add handling for newly released OPatch patches with new recommended flag

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruPatch.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruPatch.java
@@ -34,6 +34,8 @@ public class AruPatch {
     private String downloadHost;
     private String downloadPath;
     private String fileName;
+    private String access;
+    private String lifecycle;
 
     public String patchId() {
         return patchId;
@@ -103,10 +105,6 @@ public class AruPatch {
         return !Utils.isEmptyString(psuBundle);
     }
 
-    public String downloadHost() {
-        return downloadHost;
-    }
-
     public AruPatch downloadHost(String value) {
         downloadHost = value;
         return this;
@@ -132,6 +130,28 @@ public class AruPatch {
 
     public String fileName() {
         return fileName;
+    }
+
+    public AruPatch access(String value) {
+        access = value;
+        return this;
+    }
+
+    public String access() {
+        return access;
+    }
+
+    public boolean isOpenAccess() {
+        return "Open access".equals(access);
+    }
+
+    public AruPatch lifecycle(String value) {
+        lifecycle = value;
+        return this;
+    }
+
+    public boolean isRecommended() {
+        return "Recommended".equals(lifecycle);
     }
 
     /**
@@ -166,6 +186,8 @@ public class AruPatch {
                     .description(XPathUtil.string(nodeList.item(i), "./bug/abstract"))
                     .product(XPathUtil.string(nodeList.item(i), "./product/@id"))
                     .psuBundle(XPathUtil.string(nodeList.item(i), "./psu_bundle"))
+                    .access(XPathUtil.string(nodeList.item(i), "./access"))
+                    .lifecycle(XPathUtil.string(nodeList.item(i), "./life_cycle"))
                     .downloadHost(XPathUtil.string(nodeList.item(i), "./files/file/download_url/@host"))
                     .downloadPath(XPathUtil.string(nodeList.item(i), "./files/file/download_url/text()"));
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruUtil.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruUtil.java
@@ -379,11 +379,6 @@ public class AruUtil {
      * @throws XPathExpressionException if AruPatch failed while extracting patch data from the XML
      */
     public List<AruPatch> getPatches(String bugNumber, String userId, String password)
-        throws IOException, AruException, XPathExpressionException {
-        return getPatches(bugNumber, userId, password, "");
-    }
-
-    private List<AruPatch> getPatches(String bugNumber, String userId, String password, String patchSelector)
         throws AruException, IOException, XPathExpressionException {
 
         if (userId == null || password == null) {
@@ -399,30 +394,7 @@ public class AruUtil {
         } catch (NoPatchesFoundException patchEx) {
             throw new NoPatchesFoundException(Utils.getMessage("IMG-0086", bugNumber), patchEx);
         }
-        return AruPatch.getPatches(response, patchSelector);
-    }
-
-    /**
-     * Using a bug number, search ARU for a matching patch.
-     * @param bugNumber the bug number to query ARU
-     * @param userId user credentials with access to OTN
-     * @param password password for the provided userId
-     * @return an AruPatch
-     * @throws IOException if there is an error retrieving the XML from ARU
-     * @throws XPathExpressionException if AruPatch failed while extracting patch data from the XML
-     */
-    public AruPatch getPatch(String bugNumber, String userId, String password, String patchSelector)
-        throws IOException, AruException, XPathExpressionException {
-
-        List<AruPatch> patches = getPatches(bugNumber, userId, password, patchSelector);
-
-        if (patches.size() == 1) {
-            return patches.get(0);
-        } else {
-            MultiplePatchVersionsException mpe = new MultiplePatchVersionsException(bugNumber, patches);
-            logger.throwing(mpe);
-            throw mpe;
-        }
+        return AruPatch.getPatches(response, "");
     }
 
     /**

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruUtil.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruUtil.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.List;
 import javax.xml.xpath.XPathExpressionException;
 
-import com.oracle.weblogic.imagetool.cachestore.MultiplePatchVersionsException;
 import com.oracle.weblogic.imagetool.installer.FmwInstallerType;
 import com.oracle.weblogic.imagetool.logging.LoggingFacade;
 import com.oracle.weblogic.imagetool.logging.LoggingFactory;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -355,7 +355,7 @@ public abstract class CommonOptions {
     void installOpatchInstaller(String tmpDir, String opatchBugNumber)
         throws IOException, XPathExpressionException, AruException {
         logger.entering(opatchBugNumber);
-        String filePath = new OPatchFile(opatchBugNumber, userId, password, cache()).resolve(cache());
+        String filePath = OPatchFile.getInstance(opatchBugNumber, userId, password, cache()).resolve(cache());
         String filename = new File(filePath).getName();
         Files.copy(Paths.get(filePath), Paths.get(tmpDir, filename));
         dockerfileOptions.setOPatchPatchingEnabled();

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -95,7 +95,7 @@ public class UpdateImage extends CommonOptions implements Callable<CommandRespon
                 String password = getPassword();
 
                 if (shouldUpdateOpatch()) {
-                    OPatchFile opatchFile = new OPatchFile(opatchBugNumber, userId, password, cache());
+                    OPatchFile opatchFile = OPatchFile.getInstance(opatchBugNumber, userId, password, cache());
                     String opatchFilePath = opatchFile.resolve(cache());
 
                     // if there is a newer version of OPatch than contained in the image, update OPatch

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/cachestore/CachedFileTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/cachestore/CachedFileTest.java
@@ -103,7 +103,7 @@ public class CachedFileTest {
     @Test
     void latestOpatchVersion() throws IOException, AruException, XPathExpressionException {
         // OPatch file should default to the default OPatch bug number and the latest version found in cache
-        OPatchFile patchFile = new OPatchFile(null, null, null, cacheStore);
+        OPatchFile patchFile = OPatchFile.getInstance(null, null, null, cacheStore);
         assertEquals(DEFAULT_BUG_NUM + "_13.9.4.0.0", patchFile.getKey(),
             "failed to get latest Opatch version from the cache");
     }
@@ -111,7 +111,7 @@ public class CachedFileTest {
     @Test
     void specificOpatchVersion() throws IOException, AruException, XPathExpressionException {
         // OPatch file should default to the default OPatch bug number and the latest version found in cache
-        OPatchFile patchFile = new OPatchFile(DEFAULT_BUG_NUM + "_13.9.2.2.2", null, null, cacheStore);
+        OPatchFile patchFile = OPatchFile.getInstance(DEFAULT_BUG_NUM + "_13.9.2.2.2", null, null, cacheStore);
         assertEquals(DEFAULT_BUG_NUM + "_13.9.2.2.2", patchFile.getKey(),
             "failed to get specific Opatch version from the cache");
     }

--- a/imagetool/src/test/resources/patch-28186730.xml
+++ b/imagetool/src/test/resources/patch-28186730.xml
@@ -1,0 +1,248 @@
+
+<!-- Copyright (c) 2020, Oracle Corporation and/or its affiliates. -->
+<!-- Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl. -->
+
+
+<results md5_sum="8ae88f8847e373ca6cc44516717e9e07">
+    <generated_date in_epoch_ms="1606849997000">2020-12-01 19:13:17</generated_date>
+    <patch has_prereqs="n" has_postreqs="n" is_system_patch="n">
+        <bug>
+            <number>28186730</number>
+            <abstract><![CDATA[OPATCH 13.9.4.2.5 FOR EM 13.4, FMW/WLS 12.2.1.3.0, 12.2.1.4.0 AND 14.1.1.0.0]]></abstract>
+        </bug>
+        <name>28186730</name>
+        <type>Patch</type>
+        <status>Available</status>
+        <access id="m">Open access</access>
+        <url>
+            <patch_readme host="https://updates.oracle.com"><![CDATA[/Orion/Services/download?type=readme&aru=23901536]]></patch_readme>
+            <patch_details><![CDATA[/download/28186730.html]]></patch_details>
+        </url>
+        <request_id>23901536</request_id>
+        <urm_components>
+            <qparts ctype_id="201">
+                <qpart cid="468882" version="Q12753"><![CDATA[Oracle Global Lifecycle Management OPatch]]></qpart>
+            </qparts>
+            <urm_releases ctype_id="5">
+                <urm_release cid="1007556" version="13.9.4.2.5"><![CDATA[OPatch]]></urm_release>
+            </urm_releases>
+        </urm_components>
+        <product id="31944" bugdb_id="12753"><![CDATA[Oracle Global Lifecycle Management OPatch]]></product>
+        <release id="600000000159823" name="13.9.4.2.5" platform_patch_not_required="Y" cc="Y"><![CDATA[OPatch 13.9.4.2.5]]></release>
+        <platform id="2000" bugdb_id="289"><![CDATA[Generic Platform]]></platform>
+        <language id="0" iso_code="EN"><![CDATA[American English]]></language>
+        <translations_available>No</translations_available>
+        <classification id="174">General</classification>
+        <patch_classification id="174">General</patch_classification>
+        <support_level id="G">General Support</support_level>
+        <entitlements>
+            <entitlement code="SW"/>
+        </entitlements>
+        <size>45855234</size>
+        <files>
+            <file>
+                <name>p28186730_139425_Generic.zip</name>
+                <size>45855234</size>
+                <download_url host="https://updates.oracle.com"><![CDATA[/Orion/Services/download/p28186730_139425_Generic.zip?aru=23901536&patch_file=p28186730_139425_Generic.zip]]></download_url>
+                <digest type="SHA-256">8BFC99E439DA1D1663F88D6859EC19E9926A473C96B95889ABE5F45C055E1BB3</digest>
+                <digest type="SHA-1">41E3536305E6A71776717D700FA41B1A1AB0A493</digest>
+            </file>
+        </files>
+        <updated_date in_epoch_ms="1604594811000">2020-11-05 16:46:51</updated_date>
+        <released_date in_epoch_ms="1604592571000">2020-11-05 16:09:31</released_date>
+    </patch>
+    <patch has_prereqs="n" has_postreqs="n" is_system_patch="n">
+        <bug>
+            <number>28186730</number>
+            <abstract><![CDATA[OPATCH 13.9.4.2.4 FOR FMW/WLS 12.2.1.3.0, 12.2.1.4.0 AND 14.1.1.0.0]]></abstract>
+        </bug>
+        <name>28186730</name>
+        <type>Patch</type>
+        <status>Available</status>
+        <access id="m">Open access</access>
+        <url>
+            <patch_readme host="https://updates.oracle.com"><![CDATA[/Orion/Services/download?type=readme&aru=23574493]]></patch_readme>
+            <patch_details><![CDATA[/download/28186730.html]]></patch_details>
+        </url>
+        <request_id>23574493</request_id>
+        <urm_components>
+            <qparts ctype_id="201">
+                <qpart cid="468882" version="Q12753"><![CDATA[Oracle Global Lifecycle Management OPatch]]></qpart>
+            </qparts>
+            <urm_releases ctype_id="5">
+                <urm_release cid="962999" version="13.9.4.2.4"><![CDATA[OPatch]]></urm_release>
+            </urm_releases>
+        </urm_components>
+        <product id="31944" bugdb_id="12753"><![CDATA[Oracle Global Lifecycle Management OPatch]]></product>
+        <release id="600000000154942" name="13.9.4.2.4" platform_patch_not_required="Y" cc="Y"><![CDATA[OPatch 13.9.4.2.4]]></release>
+        <platform id="2000" bugdb_id="289"><![CDATA[Generic Platform]]></platform>
+        <language id="0" iso_code="EN"><![CDATA[American English]]></language>
+        <translations_available>No</translations_available>
+        <classification id="185">Security</classification>
+        <patch_classification id="185">Security</patch_classification>
+        <life_cycle id="175">Recommended</life_cycle>
+        <support_level id="G">General Support</support_level>
+        <entitlements>
+            <entitlement code="SW"/>
+        </entitlements>
+        <target_types>
+            <target_type>
+                <aru_target><![CDATA[FMW_CORE]]></aru_target>
+                <em_tag><![CDATA[oracle_ias]]></em_tag>
+            </target_type>
+        </target_types>
+        <size>45731967</size>
+        <files>
+            <file>
+                <name>p28186730_139424_Generic.zip</name>
+                <size>45731967</size>
+                <download_url host="https://updates.oracle.com"><![CDATA[/Orion/Services/download/p28186730_139424_Generic.zip?aru=23574493&patch_file=p28186730_139424_Generic.zip]]></download_url>
+                <digest type="SHA-1">1C03A8D8C54236E52FB1F4B6C49C9D161DA17D84</digest>
+                <digest type="SHA-256">0CB78A061B47B3466656BBB08EF850EF1206ECF4A350BD7E116D77E439081664</digest>
+            </file>
+        </files>
+        <updated_date in_epoch_ms="1594458862000">2020-07-11 09:14:22</updated_date>
+        <released_date in_epoch_ms="1589781020000">2020-05-18 05:50:20</released_date>
+    </patch>
+    <patch has_prereqs="n" has_postreqs="n" is_system_patch="n">
+        <bug>
+            <number>28186730</number>
+            <abstract><![CDATA[OPATCH 13.9.4.2.0 FOR FMW/WLS 12.2.1.3.0]]></abstract>
+        </bug>
+        <name>28186730</name>
+        <type>Patch</type>
+        <status>Available</status>
+        <access id="s">Password protected</access>
+        <url>
+            <patch_readme host="https://updates.oracle.com"><![CDATA[/Orion/Services/download?type=readme&aru=23342012]]></patch_readme>
+            <patch_details><![CDATA[/download/28186730.html]]></patch_details>
+        </url>
+        <request_id>23342012</request_id>
+        <urm_components>
+            <qparts ctype_id="201">
+                <qpart cid="468882" version="Q12753"><![CDATA[Oracle Global Lifecycle Management OPatch]]></qpart>
+            </qparts>
+            <urm_releases ctype_id="5">
+                <urm_release cid="887894" version="13.9.4.2.0"><![CDATA[OPatch]]></urm_release>
+            </urm_releases>
+        </urm_components>
+        <product id="31944" bugdb_id="12753"><![CDATA[Oracle Global Lifecycle Management OPatch]]></product>
+        <release id="600000000116251" name="13.9.4.2.0" platform_patch_not_required="Y" cc="Y"><![CDATA[OPatch 13.9.4.2.0]]></release>
+        <platform id="2000" bugdb_id="289"><![CDATA[Generic Platform]]></platform>
+        <language id="0" iso_code="EN"><![CDATA[American English]]></language>
+        <translations_available>No</translations_available>
+        <classification id="173">Controlled</classification>
+        <patch_classification id="173">Controlled</patch_classification>
+        <support_level id="G">General Support</support_level>
+        <entitlements>
+            <entitlement code="SW"/>
+        </entitlements>
+        <comments><![CDATA[A password is required to download this patch.  Please contact Oracle Support Services to verify the suitability of this patch and obtain the password.]]></comments>
+        <size>46242780</size>
+        <files>
+            <file>
+                <name>p28186730_139420_Generic.zip</name>
+                <size>46242780</size>
+                <download_url host="https://updates.oracle.com"><![CDATA[/Orion/Services/download/p28186730_139420_Generic.zip?aru=23342012&patch_file=p28186730_139420_Generic.zip]]></download_url>
+                <digest type="SHA-256">514233AA5C7B392798B787416F75B339E3C0FA60430C5D962DC30C7BAB68A6F3</digest>
+                <digest type="SHA-1">8D0F09675D4D7531BDB691D9DCAB5DA4387E5E8C</digest>
+            </file>
+        </files>
+        <updated_date in_epoch_ms="1579845987000">2020-01-24 06:06:27</updated_date>
+        <released_date in_epoch_ms="1579845284000">2020-01-24 05:54:44</released_date>
+    </patch>
+    <patch has_prereqs="n" has_postreqs="n" is_system_patch="n">
+        <bug>
+            <number>28186730</number>
+            <abstract><![CDATA[OPATCH 13.9.4.2.2 FOR FMW/WLS 12.2.1.3.0 AND 12.2.1.4.0]]></abstract>
+        </bug>
+        <name>28186730</name>
+        <type>Patch</type>
+        <status>Available</status>
+        <access id="d">Password protected</access>
+        <url>
+            <patch_readme host="https://updates.oracle.com"><![CDATA[/Orion/Services/download?type=readme&aru=23332459&patch_password=]]></patch_readme>
+            <patch_details><![CDATA[/download/28186730.html]]></patch_details>
+        </url>
+        <request_id>23332459</request_id>
+        <urm_components>
+            <qparts ctype_id="201">
+                <qpart cid="468882" version="Q12753"><![CDATA[Oracle Global Lifecycle Management OPatch]]></qpart>
+            </qparts>
+            <urm_releases ctype_id="5">
+                <urm_release cid="921250" version="13.9.4.2.2"><![CDATA[OPatch]]></urm_release>
+            </urm_releases>
+        </urm_components>
+        <product id="31944" bugdb_id="12753"><![CDATA[Oracle Global Lifecycle Management OPatch]]></product>
+        <release id="600000000134119" name="13.9.4.2.2" platform_patch_not_required="Y" cc="N"><![CDATA[OPatch 13.9.4.2.2]]></release>
+        <platform id="2000" bugdb_id="289"><![CDATA[Generic Platform]]></platform>
+        <language id="0" iso_code="EN"><![CDATA[American English]]></language>
+        <translations_available>No</translations_available>
+        <classification id="173">Controlled</classification>
+        <patch_classification id="173">Controlled</patch_classification>
+        <support_level id="G">General Support</support_level>
+        <entitlements>
+            <entitlement code="SW"/>
+        </entitlements>
+        <comments><![CDATA[A password is required to download this patch.  Please contact Oracle Support Services to verify the suitability of this patch and obtain the password.]]></comments>
+        <size>46620588</size>
+        <files>
+            <file>
+                <name>p28186730_139422_Generic.zip</name>
+                <size>46620588</size>
+                <download_url host="https://updates.oracle.com"><![CDATA[/Orion/Services/download/p28186730_139422_Generic.zip?aru=23332459&patch_file=p28186730_139422_Generic.zip]]></download_url>
+                <digest type="SHA-256">6167A23A45A89D48A7F638AD6E5919E24BB9202D2D821216D7E41AF3ACBA0376</digest>
+                <digest type="SHA-1">724F228313383CCD84885CB057A5E2B5E80E7132</digest>
+            </file>
+        </files>
+        <updated_date in_epoch_ms="1579671890000">2020-01-22 05:44:50</updated_date>
+        <released_date in_epoch_ms="1579583401000">2020-01-21 05:10:01</released_date>
+    </patch>
+    <patch has_prereqs="n" has_postreqs="n" is_system_patch="n">
+        <bug>
+            <number>28186730</number>
+            <abstract><![CDATA[OPATCH 13.9.4.2.1 FOR FMW/WLS 12.2.1.3.0]]></abstract>
+        </bug>
+        <name>28186730</name>
+        <type>Patch</type>
+        <status>Available</status>
+        <access id="s">Password protected</access>
+        <url>
+            <patch_readme host="https://updates.oracle.com"><![CDATA[/Orion/Services/download?type=readme&aru=23332538]]></patch_readme>
+            <patch_details><![CDATA[/download/28186730.html]]></patch_details>
+        </url>
+        <request_id>23332538</request_id>
+        <urm_components>
+            <qparts ctype_id="201">
+                <qpart cid="468882" version="Q12753"><![CDATA[Oracle Global Lifecycle Management OPatch]]></qpart>
+            </qparts>
+            <urm_releases ctype_id="5">
+                <urm_release cid="918383" version="13.9.4.2.1"><![CDATA[OPatch]]></urm_release>
+            </urm_releases>
+        </urm_components>
+        <product id="31944" bugdb_id="12753"><![CDATA[Oracle Global Lifecycle Management OPatch]]></product>
+        <release id="600000000132403" name="13.9.4.2.1" platform_patch_not_required="Y" cc="N"><![CDATA[OPatch 13.9.4.2.1]]></release>
+        <platform id="2000" bugdb_id="289"><![CDATA[Generic Platform]]></platform>
+        <language id="0" iso_code="EN"><![CDATA[American English]]></language>
+        <translations_available>No</translations_available>
+        <classification id="173">Controlled</classification>
+        <patch_classification id="173">Controlled</patch_classification>
+        <support_level id="G">General Support</support_level>
+        <entitlements>
+            <entitlement code="SW"/>
+        </entitlements>
+        <comments><![CDATA[A password is required to download this patch.  Please contact Oracle Support Services to verify the suitability of this patch and obtain the password.]]></comments>
+        <size>46518865</size>
+        <files>
+            <file>
+                <name>p28186730_139421_Generic.zip</name>
+                <size>46518865</size>
+                <download_url host="https://updates.oracle.com"><![CDATA[/Orion/Services/download/p28186730_139421_Generic.zip?aru=23332538&patch_file=p28186730_139421_Generic.zip]]></download_url>
+                <digest type="SHA-1">F7D2E3C781A6E73B3359B9246253CDBA956F29B6</digest>
+                <digest type="SHA-256">E092400E722E52627E143B6D4CB055C49815D4C987642C183DCE9F2DAFD82B2A</digest>
+            </file>
+        </files>
+        <updated_date in_epoch_ms="1579592219000">2020-01-21 07:36:59</updated_date>
+        <released_date in_epoch_ms="1579587955000">2020-01-21 06:25:55</released_date>
+    </patch>
+</results>


### PR DESCRIPTION
Newly released OPatch 13.9.4.2.5 created an issue where the Image Tool could not resolve to a single OPatch patch.  Both 13.9.4.2.5 and 13.9.4.2.4 are both listed as available for download.  This fix should allow the user to select the version of OPatch that is desired, as well as default to the recommended OPatch patch from ARU.