### PR TITLE
include recommended PSU overlay patches in --recommendedPatches

### DIFF
--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/aru/AruUtilTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/aru/AruUtilTest.java
@@ -67,7 +67,7 @@ class AruUtilTest {
                                                String password) throws XPathExpressionException, AruException {
             Document result;
             try {
-                if (releaseNumber.equals("336")) {
+                if (releaseNumber.equals("336") || releaseNumber.equals("304")) {
                     result = getResource("/recommended-patches.xml");
                 } else {
                     result = getResource("/no-patches.xml");

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/aru/AruUtilTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/aru/AruUtilTest.java
@@ -67,6 +67,7 @@ class AruUtilTest {
                                                String password) throws XPathExpressionException, AruException {
             Document result;
             try {
+                // these release numbers are fake test data from the fake releases.xml found in test/resources
                 if (releaseNumber.equals("336") || releaseNumber.equals("304")) {
                     result = getResource("/recommended-patches.xml");
                 } else {


### PR DESCRIPTION
Recommended PSU overlay patches include security fixes and should be included in the set of patches returned from --recommendedPatches.  Unfortunately, ARU metadata does not include the recommended overlays unless the release requested is the PSU version, and not the GA version.