### PR TITLE
Ol8 locale warning

### DIFF
--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -151,8 +151,7 @@ RUN cd {{{tempDir}}}/opatch \
     LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
     ENV WLSDEPLOY_PROPERTIES="{{{wlsdeploy_properties}}} -Djava.security.egd=file:/dev/./urandom" \
-        LC_ALL=${DEFAULT_LOCALE:-en_US.UTF-8} \
-        DOMAIN_HOME={{{domain_home}}}
+    DOMAIN_HOME={{{domain_home}}}
 
     COPY --chown={{userid}}:{{groupid}} {{{wdtInstaller}}} {{{tempDir}}}/
 
@@ -235,7 +234,6 @@ ENV ORACLE_HOME={{{oracle_home}}} \
     MANAGED_SERVER_PORT=${MANAGED_SERVER_PORT:-8001} \
     DOMAIN_HOME={{{domain_home}}} \
 {{/isWdtEnabled}}
-    LC_ALL=${DEFAULT_LOCALE:-en_US.UTF-8} \
     PATH=${PATH}:{{{java_home}}}/bin:{{{oracle_home}}}/oracle_common/common/bin:{{{oracle_home}}}/wlserver/common/bin:{{{oracle_home}}}{{#isWdtEnabled}}:${{{domain_home}}}/bin{{/isWdtEnabled}}
 
 LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"

--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -151,7 +151,7 @@ RUN cd {{{tempDir}}}/opatch \
     LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
     ENV WLSDEPLOY_PROPERTIES="{{{wlsdeploy_properties}}} -Djava.security.egd=file:/dev/./urandom" \
-    DOMAIN_HOME={{{domain_home}}}
+        DOMAIN_HOME={{{domain_home}}}
 
     COPY --chown={{userid}}:{{groupid}} {{{wdtInstaller}}} {{{tempDir}}}/
 

--- a/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
@@ -179,7 +179,6 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
     {{#installJava}}
         JAVA_HOME={{{java_home}}} \
     {{/installJava}}
-    LC_ALL=${DEFAULT_LOCALE:-en_US.UTF-8} \
     PATH=${PATH}:{{{java_home}}}/bin:{{{oracle_home}}}/oracle_common/common/bin:{{{oracle_home}}}/wlserver/common/bin:{{{oracle_home}}}
 
     LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"

--- a/imagetool/src/main/resources/docker-files/Update_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Update_Image.mustache
@@ -10,7 +10,6 @@
     LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
     ENV WLSDEPLOY_PROPERTIES={{{wlsdeploy_properties}}} \
-        LC_ALL=${DEFAULT_LOCALE:-en_US.UTF-8} \
         DOMAIN_HOME={{{domain_home}}} \
         PATH=${PATH}:{{{java_home}}}/bin:{{{oracle_home}}}/oracle_common/common/bin:{{{oracle_home}}}/wlserver/common/bin:{{{domain_home}}}/bin:{{{oracle_home}}}
 


### PR DESCRIPTION
The locales were removed from the Oracle Linux 8-slim image.  Setting LC_ALL in the image ENV is optional, and so removed to make using OL8-slim cleaner.