### PR TITLE
allow base image to have an existing /u01 folder

### DIFF
--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -42,7 +42,7 @@ RUN zypper -nq update \
 ## Create user and group
 RUN if [ -z "$(getent group {{groupid}})" ]; then hash groupadd &> /dev/null && groupadd {{groupid}} || exit -1 ; fi \
  && if [ -z "$(getent passwd {{userid}})" ]; then hash useradd &> /dev/null && useradd -g {{groupid}} {{userid}} || exit -1; fi \
- && mkdir /u01 \
+ && mkdir -p /u01 \
  && chown {{userid}}:{{groupid}} /u01 \
  && chmod 775 /u01
 

--- a/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
@@ -64,7 +64,7 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
     ## Create user and group
     RUN if [ -z "$(getent group {{groupid}})" ]; then hash groupadd &> /dev/null && groupadd {{groupid}} || exit -1 ; fi \
     && if [ -z "$(getent passwd {{userid}})" ]; then hash useradd &> /dev/null && useradd -g {{groupid}} {{userid}} || exit -1; fi \
-    && mkdir /u01 \
+    && mkdir -p /u01 \
     && chown {{userid}}:{{groupid}} /u01 \
     && chmod 775 /u01
 


### PR DESCRIPTION
If the --fromImage contains a /u01 folder, the image create should not fail.  For example, if the user wants to install Java in /u01/java and use this as the --fromImage, the Image Tool should be able to handle this use case.