### PR TITLE
Work-around for Docker bug in BuildKit

### DIFF
--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -4,7 +4,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 #
-FROM {{baseImage}} as OS_UPDATE
+FROM {{baseImage}} as os_update
 LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 USER root
 
@@ -48,7 +48,7 @@ RUN if [ -z "$(getent group {{groupid}})" ]; then hash groupadd &> /dev/null && 
 
 {{#installJava}}
 # Install Java
-FROM OS_UPDATE as JDK_BUILD
+FROM os_update as jdk_build
 LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
 ENV JAVA_HOME={{{java_home}}}
@@ -72,7 +72,7 @@ RUN tar xzf {{{tempDir}}}/{{java_pkg}} -C /u01 \
 {{/installJava}}
 
 # Install Middleware
-FROM OS_UPDATE as WLS_BUILD
+FROM os_update as wls_build
 LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
 ENV JAVA_HOME={{{java_home}}} \
@@ -88,7 +88,7 @@ RUN mkdir -p {{{oracle_home}}} \
  && chown {{userid}}:{{groupid}} {{orainv_dir}} \
  && chown {{userid}}:{{groupid}} {{{oracle_home}}}
 
-{{#installJava}}COPY --from=JDK_BUILD --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
+{{#installJava}}COPY --from=jdk_build --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
 {{/installJava}}
 
 {{#installPackages}}COPY --chown={{userid}}:{{groupid}} {{installerFilename}} {{responseFile.name}} {{{tempDir}}}/
@@ -146,7 +146,7 @@ RUN cd {{{tempDir}}}/opatch \
 {{/afterFmwInstall}}
 
 {{#isWdtEnabled}}
-    FROM WLS_BUILD as WDT_BUILD
+    FROM wls_build as wdt_build
     ARG WDT_ENCRYPTION_KEY
     LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
@@ -215,7 +215,7 @@ RUN cd {{{tempDir}}}/opatch \
 
 {{/isWdtEnabled}}
 
-FROM OS_UPDATE as FINAL_BUILD
+FROM os_update as final_build
 
 ARG ADMIN_NAME
 ARG ADMIN_HOST
@@ -239,15 +239,15 @@ ENV ORACLE_HOME={{{oracle_home}}} \
 LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
 {{#installJava}}
-    COPY --from=JDK_BUILD --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
+    COPY --from=jdk_build --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
 {{/installJava}}
 
-COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle_home}}}/
+COPY --from=wls_build --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle_home}}}/
 {{#copyOraInst}}
-    COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{inv_loc}}/oraInst.loc  {{inv_loc}}/oraInst.loc
+    COPY --from=wls_build --chown={{userid}}:{{groupid}} {{inv_loc}}/oraInst.loc  {{inv_loc}}/oraInst.loc
 {{/copyOraInst}}
 {{#copyOraInventoryDir}}
-    COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{orainv_dir}} {{orainv_dir}}/
+    COPY --from=wls_build --chown={{userid}}:{{groupid}} {{orainv_dir}} {{orainv_dir}}/
 {{/copyOraInventoryDir}}
 
 {{#isWdtEnabled}}
@@ -258,13 +258,13 @@ COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle
         && chmod g+w $DOMAIN_PARENT \
         && mkdir -p {{{wdt_model_home}}} \
         && chmod g+w {{{wdt_model_home}}}
-        COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
+        COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
         {{#isWdtModelHomeOutsideWdtHome}}
-            COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_model_home}} {{wdt_model_home}}/
+            COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{wdt_model_home}} {{wdt_model_home}}/
         {{/isWdtModelHomeOutsideWdtHome}}
     {{/modelOnly}}
     {{^modelOnly}}
-        COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{{domain_home}}} {{{domain_home}}}/
+        COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{{domain_home}}} {{{domain_home}}}/
         RUN chmod g+w {{{domain_home}}}
     {{/modelOnly}}
 {{/isWdtEnabled}}

--- a/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
@@ -6,8 +6,8 @@
 #
 
 {{#isRebaseToTarget}}
-FROM {{sourceImage}} as SOURCE_IMAGE
-FROM {{targetImage}} as FINAL_BUILD
+FROM {{sourceImage}} as source_image
+FROM {{targetImage}} as final_build
 ARG ADMIN_PORT
 ARG MANAGED_SERVER_PORT
 
@@ -18,8 +18,8 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
 {{/isRebaseToTarget}}
 {{#isRebaseToNew}}
-    FROM {{sourceImage}} as SOURCE_IMAGE
-    FROM {{baseImage}} as OS_UPDATE
+    FROM {{sourceImage}} as source_image
+    FROM {{baseImage}} as os_update
     ARG ADMIN_PORT
     ARG MANAGED_SERVER_PORT
 
@@ -70,7 +70,7 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
     {{#installJava}}
         # Install Java
-        FROM OS_UPDATE as JDK_BUILD
+        FROM os_update as jdk_build
         LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
         ENV JAVA_HOME={{{java_home}}}
@@ -93,7 +93,7 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
         {{/afterJdkInstall}}
     {{/installJava}}
 
-    FROM OS_UPDATE as WLS_BUILD
+    FROM os_update as wls_build
     # Install middleware
     LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
@@ -111,7 +111,7 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
     && chown {{userid}}:{{groupid}} {{{oracle_home}}}
 
     {{#installJava}}
-        COPY --from=JDK_BUILD --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
+        COPY --from=jdk_build --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
     {{/installJava}}
 
     {{#installPackages}}COPY --chown={{userid}}:{{groupid}} {{installerFilename}} {{responseFile.name}} {{{tempDir}}}/
@@ -168,7 +168,7 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
     {{/afterFmwInstall}}
 
 
-    FROM OS_UPDATE as FINAL_BUILD
+    FROM os_update as final_build
 
     ARG ADMIN_NAME
     ARG ADMIN_HOST
@@ -184,21 +184,21 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
     LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
     {{#installJava}}
-        COPY --from=JDK_BUILD --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
+        COPY --from=jdk_build --chown={{userid}}:{{groupid}} {{{java_home}}} {{{java_home}}}/
     {{/installJava}}
 
-    COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle_home}}}/
+    COPY --from=wls_build --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle_home}}}/
     {{#copyOraInst}}
-        COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{inv_loc}}/oraInst.loc  {{inv_loc}}/oraInst.loc
+        COPY --from=wls_build --chown={{userid}}:{{groupid}} {{inv_loc}}/oraInst.loc  {{inv_loc}}/oraInst.loc
     {{/copyOraInst}}
     {{#copyOraInventoryDir}}
-        COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{orainv_dir}} {{orainv_dir}}/
+        COPY --from=wls_build --chown={{userid}}:{{groupid}} {{orainv_dir}} {{orainv_dir}}/
     {{/copyOraInventoryDir}}
 {{/isRebaseToNew}}
 
 USER {{userid}}
 RUN mkdir -p {{domain_home}}
-COPY --from=SOURCE_IMAGE --chown={{userid}}:{{groupid}} {{domain_home}} {{domain_home}}/
+COPY --from=source_image --chown={{userid}}:{{groupid}} {{domain_home}} {{domain_home}}/
 RUN chmod g+w {{{domain_home}}}
 
 EXPOSE $ADMIN_PORT $MANAGED_SERVER_PORT

--- a/imagetool/src/main/resources/docker-files/Update_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Update_Image.mustache
@@ -5,7 +5,7 @@
 #
 #
 {{#isWdtEnabled}}
-    FROM {{baseImage}} as WDT_BUILD
+    FROM {{baseImage}} as wdt_build
     ARG WDT_ENCRYPTION_KEY
     LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
@@ -79,7 +79,7 @@
     {{/afterWdtCommand}}
 {{/isWdtEnabled}}
 
-FROM {{baseImage}} as FINAL_BUILD
+FROM {{baseImage}} as final_build
 USER root
 
 ENV OPATCH_NO_FUSER=true
@@ -133,13 +133,13 @@ USER {{userid}}
         && chmod g+w $DOMAIN_PARENT \
         && mkdir -p {{{wdt_model_home}}} \
         && chmod g+w {{{wdt_model_home}}}
-        COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
+        COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
         {{#isWdtModelHomeOutsideWdtHome}}
-            COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_model_home}} {{wdt_model_home}}/
+            COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{wdt_model_home}} {{wdt_model_home}}/
         {{/isWdtModelHomeOutsideWdtHome}}
     {{/modelOnly}}
     {{^modelOnly}}
-        COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{{domain_home}}} {{{domain_home}}}/
+        COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{{domain_home}}} {{{domain_home}}}/
         RUN chmod g+w {{{domain_home}}}
     {{/modelOnly}}
 {{/isWdtEnabled}}


### PR DESCRIPTION
Docker has not fixed the bug in the new buildkit for quite some time.  And worse, the new install defaults to enabling the new buildkit feature.  This Docker bug causes the Docker build step in Image Tool to fail with:
`failed to solve with frontend dockerfile.v0: failed to create LLB definition: failed to parse stage name "OS_UPDATE": invalid reference format: repository name must be lowercase`

To see the error, the buildkit must be enabled in the Docker preferences/config:
{
  "debug": true,
  "experimental": false,
  "features": {"buildkit": true }
}