### PR TITLE
Added modelHome variable for Verrazzano/WKO templates

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/WdtOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/WdtOptions.java
@@ -134,6 +134,7 @@ public class WdtOptions {
         ResourceTemplateOptions options = new ResourceTemplateOptions()
             .domainHome(wdtDomainHome)
             .imageName(imageName)
+            .modelHome(wdtModelHome)
             .domainHomeSourceType(domainType);
 
         // resolve parameters in the list of mustache templates returned by gatherFiles()

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/ResourceTemplateOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/ResourceTemplateOptions.java
@@ -9,6 +9,7 @@ package com.oracle.weblogic.imagetool.util;
 public class ResourceTemplateOptions {
     private String imageName;
     private String domainHome;
+    private String modelHome;
     private DomainHomeSourceType domainHomeSourceType = DomainHomeSourceType.PV;
 
 
@@ -17,6 +18,7 @@ public class ResourceTemplateOptions {
      *
      * @return image tag name
      */
+    @SuppressWarnings("unused")
     public String imageName() {
         return imageName;
     }
@@ -37,6 +39,7 @@ public class ResourceTemplateOptions {
      *
      * @return domain home value
      */
+    @SuppressWarnings("unused")
     public String domainHome() {
         return domainHome;
     }
@@ -60,6 +63,7 @@ public class ResourceTemplateOptions {
      *
      * @return domain home source type
      */
+    @SuppressWarnings("unused")
     public String domainHomeSourceType() {
         return domainHomeSourceType.toString();
     }
@@ -72,6 +76,27 @@ public class ResourceTemplateOptions {
      */
     public ResourceTemplateOptions domainHomeSourceType(DomainHomeSourceType value) {
         domainHomeSourceType = value;
+        return this;
+    }
+
+    /**
+     * Return the model home passed in the --wdtModelHome argument or the default if not provided.
+     *
+     * @return the location where the models will be written in the image, for --modelOnly
+     */
+    @SuppressWarnings("unused")
+    public String modelHome() {
+        return modelHome;
+    }
+
+    /**
+     * Set the model home.
+     *
+     * @param value the model home from the --wdtModelHome argument
+     * @return builder/this
+     */
+    public ResourceTemplateOptions modelHome(String value) {
+        modelHome = value;
         return this;
     }
 }

--- a/site/create-image.md
+++ b/site/create-image.md
@@ -30,7 +30,7 @@ Usage: imagetool create [OPTIONS]
 | `--passwordFile` | Path to a file containing just the Oracle Support password, see `--user`.  |   |
 | `--patches` | Comma separated list of patch IDs. Example: `12345678,87654321`  |   |
 | `--pull` | Always attempt to pull a newer version of base images during the build.  |   |
-| `--resourceTemplates` | One or more files containing placeholders that need to be resolved by the Image Tool, such as {{{imageName}}}. See [Resource Template Files](#resource-template-files). |   |
+| `--resourceTemplates` | One or more files containing placeholders that need to be resolved by the Image Tool. See [Resource Template Files](#resource-template-files). |   |
 | `--strictPatchOrdering` |  Instruct OPatch to apply patches one at a time (uses `apply` instead of `napply`). |   |
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0`  |   |
 | `--type` | Installer type. Supported values: `WLS`, `WLSDEV`, `WLSSLIM`, `FMW`, `IDM`, `OSB`, `OUD_WLS`, `SOA_OSB`, `WCP`, `OAM`, `OIG`, `OUD`, `SOA`, `WCC`, `WCS`, `WCP`  | `WLS`  |
@@ -109,7 +109,7 @@ the Mustache syntax, like `{{imageName}}` or `{{{imageName}}}`.
 | Token Name | Value Description | 
 | --- | --- |
 | `domainHome` | The value provided to the Image Tool with `--wdtDomainHome`. |
-| `domainHomeSourceType` | `PersistentVolume` (default), `FromModel` if `wdtModelOnly`, or Image if the domain is created in the image with WDT. |
+| `domainHomeSourceType` | `PersistentVolume` (default), `FromModel` if `--wdtModelOnly`, or `Image` if the domain is created in the image with WDT. |
 | `imageName` | The value provided to the Image Tool with `--tag`. |
 | `modelHome` | The value provided to the Image Tool with `--wdtModelHome`. |
 

--- a/site/create-image.md
+++ b/site/create-image.md
@@ -30,6 +30,7 @@ Usage: imagetool create [OPTIONS]
 | `--passwordFile` | Path to a file containing just the Oracle Support password, see `--user`.  |   |
 | `--patches` | Comma separated list of patch IDs. Example: `12345678,87654321`  |   |
 | `--pull` | Always attempt to pull a newer version of base images during the build.  |   |
+| `--resourceTemplates` | One or more files containing placeholders that need to be resolved by the Image Tool, such as {{{imageName}}}. See [Resource Template Files](#resource-template-files). |   |
 | `--strictPatchOrdering` |  Instruct OPatch to apply patches one at a time (uses `apply` instead of `napply`). |   |
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0`  |   |
 | `--type` | Installer type. Supported values: `WLS`, `WLSDEV`, `WLSSLIM`, `FMW`, `IDM`, `OSB`, `OUD_WLS`, `SOA_OSB`, `WCP`, `OAM`, `OIG`, `OUD`, `SOA`, `WCC`, `WCS`, `WCP`  | `WLS`  |
@@ -98,6 +99,19 @@ on when the build needs access to the file.  For example, if the file is needed 
 installation or domain creation steps, use the `final-build-commands` section so that the `COPY` command occurs in the 
 final stage of the image build.  Or, if the file needs to change the Oracle Home prior to domain creation, use 
 the `after-fmw-install` or `before-wdt-command` sections.
+
+#### Resource Template Files
+
+If provided, the file or files provided with `--resourceTemplates` will be overwritten. For known tokens, 
+the placeholders will be replaced with values according to the table below.  **Note:** Placeholders must follow
+the Mustache syntax, like `{{imageName}}` or `{{{imageName}}}`.
+
+| Token Name | Value Description | 
+| --- | --- |
+| `domainHome` | The value provided to the Image Tool with `--wdtDomainHome`. |
+| `domainHomeSourceType` | `PersistentVolume` (default), `FromModel` if `wdtModelOnly`, or Image if the domain is created in the image with WDT. |
+| `imageName` | The value provided to the Image Tool with `--tag`. |
+| `modelHome` | The value provided to the Image Tool with `--wdtModelHome`. |
 
 #### Use an argument file
 

--- a/site/create-image.md
+++ b/site/create-image.md
@@ -103,7 +103,7 @@ the `after-fmw-install` or `before-wdt-command` sections.
 #### Resource Template Files
 
 If provided, the file or files provided with `--resourceTemplates` will be overwritten. For known tokens, 
-the placeholders will be replaced with values according to the table below.  **Note:** Placeholders must follow
+the placeholders will be replaced with values according to the following table.  **Note:** Placeholders must follow
 the Mustache syntax, like `{{imageName}}` or `{{{imageName}}}`.
 
 | Token Name | Value Description | 

--- a/site/update-image.md
+++ b/site/update-image.md
@@ -39,6 +39,7 @@ Update WebLogic Docker image with selected patches
 | `--passwordFile` | Path to a file containing just the Oracle Support password, see `--user`.  |   |
 | `--patches` | Comma separated list of patch IDs. Example: `12345678,87654321`  |   |
 | `--pull` | Always attempt to pull a newer version of base images during the build.  |   |
+| `--resourceTemplates` | One or more files containing placeholders that need to be resolved by the Image Tool, such as {{{imageName}}}. See [Resource Template Files](#resource-template-files). |   |
 | `--strictPatchOrdering` |  Instruct OPatch to apply patches one at a time (uses `apply` instead of `napply`). |   |
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0`  |   |
 | `--user` | Oracle support email ID.  |   |
@@ -108,6 +109,19 @@ the `after-fmw-install` or `before-wdt-command` sections.
 The `latestPSU` option will continue to be supported for the CREATE option, but has been deprecated for use in the 
 UPDATE option.  Because of the number of patches and their size, using `latestPSU` as an update to an existing image can 
 increase the size of the image significantly, and is not recommended. 
+
+#### Resource Template Files
+
+If provided, the file or files provided with `--resourceTemplates` will be overwritten. For known tokens, 
+the placeholders will be replaced with values according to the table below.  **Note:** Placeholders must follow
+the Mustache syntax, like `{{imageName}}` or `{{{imageName}}}`.
+
+| Token Name | Value Description | 
+| --- | --- |
+| `domainHome` | The value provided to the Image Tool with `--wdtDomainHome`. |
+| `domainHomeSourceType` | `PersistentVolume` (default), `FromModel` if `wdtModelOnly`, or Image if the domain is created in the image with WDT. |
+| `imageName` | The value provided to the Image Tool with `--tag`. |
+| `modelHome` | The value provided to the Image Tool with `--wdtModelHome`. |
 
 #### Use an argument file
 

--- a/site/update-image.md
+++ b/site/update-image.md
@@ -39,7 +39,7 @@ Update WebLogic Docker image with selected patches
 | `--passwordFile` | Path to a file containing just the Oracle Support password, see `--user`.  |   |
 | `--patches` | Comma separated list of patch IDs. Example: `12345678,87654321`  |   |
 | `--pull` | Always attempt to pull a newer version of base images during the build.  |   |
-| `--resourceTemplates` | One or more files containing placeholders that need to be resolved by the Image Tool, such as {{{imageName}}}. See [Resource Template Files](#resource-template-files). |   |
+| `--resourceTemplates` | One or more files containing placeholders that need to be resolved by the Image Tool. See [Resource Template Files](#resource-template-files). |   |
 | `--strictPatchOrdering` |  Instruct OPatch to apply patches one at a time (uses `apply` instead of `napply`). |   |
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0`  |   |
 | `--user` | Oracle support email ID.  |   |
@@ -119,7 +119,7 @@ the Mustache syntax, like `{{imageName}}` or `{{{imageName}}}`.
 | Token Name | Value Description | 
 | --- | --- |
 | `domainHome` | The value provided to the Image Tool with `--wdtDomainHome`. |
-| `domainHomeSourceType` | `PersistentVolume` (default), `FromModel` if `wdtModelOnly`, or Image if the domain is created in the image with WDT. |
+| `domainHomeSourceType` | `PersistentVolume` (default), `FromModel` if `--wdtModelOnly`, or `Image` if the domain is created in the image with WDT. |
 | `imageName` | The value provided to the Image Tool with `--tag`. |
 | `modelHome` | The value provided to the Image Tool with `--wdtModelHome`. |
 

--- a/site/update-image.md
+++ b/site/update-image.md
@@ -113,7 +113,7 @@ increase the size of the image significantly, and is not recommended.
 #### Resource Template Files
 
 If provided, the file or files provided with `--resourceTemplates` will be overwritten. For known tokens, 
-the placeholders will be replaced with values according to the table below.  **Note:** Placeholders must follow
+the placeholders will be replaced with values according to the following table.  **Note:** Placeholders must follow
 the Mustache syntax, like `{{imageName}}` or `{{{imageName}}}`.
 
 | Token Name | Value Description | 


### PR DESCRIPTION
Provide documentation for --resourceTemplates parameter, and added {{modelHome}} as a new token for resource templates.