### PR TITLE
Add --force option to addInstaller and addPatch

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/AddInstallerEntry.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/AddInstallerEntry.java
@@ -3,37 +3,24 @@
 
 package com.oracle.weblogic.imagetool.cli.cache;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-
 import com.oracle.weblogic.imagetool.api.model.CommandResponse;
 import com.oracle.weblogic.imagetool.cachestore.CacheStore;
 import com.oracle.weblogic.imagetool.cachestore.CacheStoreException;
 import com.oracle.weblogic.imagetool.installer.InstallerType;
-import com.oracle.weblogic.imagetool.util.Utils;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
-
-import static com.oracle.weblogic.imagetool.cachestore.CacheStoreFactory.cache;
 
 @Command(
         name = "addInstaller",
         description = "Add cache entry for wls, fmw, jdk or wdt installer",
         sortOptions = false
 )
-public class AddInstallerEntry extends CacheOperation {
+public class AddInstallerEntry extends CacheAddOperation {
 
     @Override
     public CommandResponse call() throws CacheStoreException {
-        if (location != null && Files.isRegularFile(location) && !Utils.isEmptyString(version)) {
-            String key = String.format("%s%s%s", type, CacheStore.CACHE_KEY_SEPARATOR, version);
-            if (cache().getValueFromCache(key) != null) {
-                return new CommandResponse(-1, "IMG-0048", key, cache().getValueFromCache(key));
-            }
-            cache().addToCache(key, location.toAbsolutePath().toString());
-            return new CommandResponse(0, "IMG-0050", key, cache().getValueFromCache(key));
-        }
-        return new CommandResponse(-1, "IMG-0049", location);
+        String key = String.format("%s%s%s", type, CacheStore.CACHE_KEY_SEPARATOR, version);
+        return addToCache(key);
     }
 
     @Option(
@@ -51,10 +38,4 @@ public class AddInstallerEntry extends CacheOperation {
     )
     private String version;
 
-    @Option(
-            names = {"--path"},
-            description = "Location on disk. For ex: /path/to/FMW/installer.zip",
-            required = true
-    )
-    private Path location;
 }

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/CacheAddOperation.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/CacheAddOperation.java
@@ -1,0 +1,61 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.weblogic.imagetool.cli.cache;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.oracle.weblogic.imagetool.api.model.CommandResponse;
+import com.oracle.weblogic.imagetool.cachestore.CacheStoreException;
+import picocli.CommandLine;
+
+import static com.oracle.weblogic.imagetool.cachestore.CacheStoreFactory.cache;
+
+public abstract class CacheAddOperation extends CacheOperation {
+
+    CommandResponse addToCache(String key) throws CacheStoreException {
+        // if file is invalid or does not exist, return an error
+        if (filePath == null || !Files.isRegularFile(filePath)) {
+            return new CommandResponse(-1, "IMG-0049", filePath);
+        }
+
+        // if the new value is the same as the existing cache value, do nothing
+        String existingValue = cache().getValueFromCache(key);
+        if (absolutePath().toString().equals(existingValue)) {
+            return new CommandResponse(0, "IMG-0075");
+        }
+
+        // if there is already a cache entry and the user did not ask to force it, return an error
+        if (!force && existingValue != null) {
+            return new CommandResponse(-1, "IMG-0048", key, existingValue);
+        }
+
+        // input appears valid, add the entry to the cache and exit
+        cache().addToCache(key, absolutePath().toString());
+        return new CommandResponse(0, "IMG-0050", key, cache().getValueFromCache(key));
+    }
+
+    Path absolutePath() {
+        if (absolutePath == null) {
+            absolutePath = filePath.toAbsolutePath();
+        }
+        return absolutePath;
+    }
+
+    private Path absolutePath = null;
+
+    @CommandLine.Option(
+        names = {"--force"},
+        description = "Overwrite existing entry, if it exists"
+    )
+    private boolean force = false;
+
+
+    @CommandLine.Option(
+        names = {"--path"},
+        description = "Location on disk. For ex: /path/to/patch-or-installer.zip",
+        required = true
+    )
+    private Path filePath;
+}

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -46,9 +46,9 @@ IMG-0044=Invalid arguments. Both --key and --path are required parameters, and c
 IMG-0045=Invalid argument. The value for --key should correspond to a valid entry in the cache.
 IMG-0046=Deleted all entries from cache
 IMG-0047=cache is empty
-IMG-0048=Installer already exists {0}={1}. Try removing it, before adding it again:  imagetool cache deleteEntry --key={0}
-IMG-0049=Could not find value for --path, file not found: {0}
-IMG-0050=Successfully added to cache. {0}={1}
+IMG-0048=Entry {0} already exists as {1}. Use --force to override the entry, or remove the existing entry first:  imagetool cache deleteEntry --key={0}
+IMG-0049=File not found, invalid value for --path {0}
+IMG-0050=Successfully added to cache. [[cyan: {0}]]={1}
 IMG-0051=Deleted entry [[cyan: {0}]]={1}
 IMG-0052=Nothing to delete for key: {0}
 IMG-0053=[[brightgreen: Build successful.]] Build time={0}s. Image tag={1}
@@ -73,10 +73,10 @@ IMG-0071=WDT Operation is set to UPDATE, but the DOMAIN_HOME environment variabl
 IMG-0072=ORACLE_HOME environment variable is not defined in the base image: {0}
 IMG-0073=Invalid file {0} listed for --resourceTemplates
 IMG-0074=OPatch will not be updated, fromImage has version {0}, available version is {1}
-IMG-0075=Added patch entry [[cyan: {0}]]={1}
-IMG-0076=Cache key {0} already exists, remove it first
+IMG-0075=Nothing to do, cache entry already exists
+IMG-0076=Invalid argument, the value provided for {0} is invalid or empty.
 IMG-0077=Skipping duplicate patch {0}. Patch file already exists in the build context folder. Did you accidentally list the patch twice?
-IMG-0078=[[cyan: --type]] is [[brightred: DEPRECATED]] and will be removed in an upcoming release.
+IMG-0078=REMOVED
 IMG-0079=OS Package Manager override, changed from {0} to {1}
 IMG-0080=Argument {0} does not match any FmwInstallerType names
 IMG-0081=Unable to retrieve list of Oracle releases from Oracle Updates (ARU). Try again later.


### PR DESCRIPTION
Changed ADD behavior slightly.  If the entry being added is an exact match for key and content, the add operation no longer fails.  This allows the same add operation to be run multiple times without failing.  This should help in test and sample scenarios that repeat steps.  When used from the command line, the user in this scenario will receive a message that nothing was changed.

Additionally, `--force` was added as an option to both addPatch and addInstaller to allow the user to override the existing entry with new content without requiring the user to delete the existing entry first.

