### PR TITLE
ensure that all images have findutils installed for k8s operator

### DIFF
--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -9,13 +9,13 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 USER root
 
 {{#useYum}}
-RUN yum -y --downloaddir={{{tempDir}}} install gzip tar unzip libaio jq {{#osPackages}}{{{.}}} {{/osPackages}}\
+RUN yum -y --downloaddir={{{tempDir}}} install gzip tar unzip libaio jq findutils {{#osPackages}}{{{.}}} {{/osPackages}}\
  && yum -y --downloaddir={{{tempDir}}} clean all \
  && rm -rf /var/cache/yum/* \
  && rm -rf {{{tempDir}}}
 {{/useYum}}
 {{#useDnf}}
-RUN dnf -y install gzip tar unzip libaio jq {{#osPackages}}{{{.}}} {{/osPackages}}\
+RUN dnf -y install gzip tar unzip libaio jq findutils {{#osPackages}}{{{.}}} {{/osPackages}}\
  && dnf clean all
 {{/useDnf}}
 {{#useMicroDnf}}
@@ -25,7 +25,7 @@ RUN microdnf install gzip tar unzip libaio jq findutils diffutils shadow-utils {
 {{#useAptGet}}
 RUN apt-get -y update \
  && apt-get -y upgrade \
- && apt-get -y install gzip tar unzip libaio jq {{#osPackages}}{{{.}}} {{/osPackages}}\
+ && apt-get -y install gzip tar unzip libaio jq findutils {{#osPackages}}{{{.}}} {{/osPackages}}\
  && apt-get -y clean all
 {{/useAptGet}}
 {{#useApk}}

--- a/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
@@ -31,7 +31,7 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
     USER root
 
     {{#useYum}}
-        RUN yum -y --downloaddir={{{tempDir}}} install gzip tar unzip libaio jq \
+        RUN yum -y --downloaddir={{{tempDir}}} install gzip tar unzip libaio jq findutils diffutils \
         && yum -y --downloaddir={{{tempDir}}} clean all \
         && rm -rf /var/cache/yum/* \
         && rm -rf {{{tempDir}}}
@@ -47,7 +47,7 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
     {{#useAptGet}}
         RUN apt-get -y update \
         && apt-get -y upgrade \
-        && apt-get -y install gzip tar unzip libaio jq \
+        && apt-get -y install gzip tar unzip libaio jq findutils diffutils \
         && apt-get -y clean all
     {{/useAptGet}}
     {{#useApk}}


### PR DESCRIPTION
yum install will ignore any packages that are already installed.  Since WLS K8s Operator requires `find`, this change will ensure that the find utility is installed even if the base linux distribution changes.