### PR TITLE
Enable experimental Podman support 

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/builder/BuildCommand.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/builder/BuildCommand.java
@@ -34,7 +34,7 @@ public class BuildCommand {
 
     /**
      * Create a build command for creating an image.  At some point, it might
-     * be beneficial to subclass this with separate classes for each builder (docker, podman, ...).
+     * be beneficial to subclass this with separate classes for each builder (docker or podman).
      * For now, the differences do not justify the extra complexity.
      */
     public BuildCommand(String buildEngine, String contextFolder) {

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/builder/BuildCommand.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/builder/BuildCommand.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.builder;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -95,7 +95,7 @@ public abstract class CommonOptions {
     }
 
     void runDockerCommand(String dockerfile, BuildCommand command) throws IOException, InterruptedException {
-        logger.info("Starting build: " + command.toString());
+        logger.info("IMG-0078", command.toString());
 
         if (dryRun) {
             System.out.println("########## BEGIN DOCKERFILE ##########");
@@ -359,7 +359,7 @@ public abstract class CommonOptions {
             Utils.copyResourceAsFile("/probe-env/test-create-env.sh",
                 tmpDir + File.separator + "test-env.sh", true);
 
-            Properties baseImageProperties = Utils.getBaseImageProperties(fromImage, tmpDir);
+            Properties baseImageProperties = Utils.getBaseImageProperties(buildEngine, fromImage, tmpDir);
 
             if (baseImageProperties.getProperty("WLS_VERSION", null) != null) {
                 throw new IllegalArgumentException(Utils.getMessage("IMG-0038", fromImage,

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
@@ -105,7 +105,7 @@ public class CreateImage extends CommonOptions implements Callable<CommandRespon
         } finally {
             if (!skipcleanup) {
                 Utils.deleteFilesRecursively(tmpDir);
-                Utils.removeIntermediateDockerImages(buildId);
+                Utils.removeIntermediateDockerImages(buildEngine, buildId);
             }
         }
         Instant endTime = Instant.now();

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
@@ -14,13 +14,13 @@ import java.util.concurrent.Callable;
 
 import com.oracle.weblogic.imagetool.api.model.CachedFile;
 import com.oracle.weblogic.imagetool.api.model.CommandResponse;
+import com.oracle.weblogic.imagetool.builder.BuildCommand;
 import com.oracle.weblogic.imagetool.installer.FmwInstallerType;
 import com.oracle.weblogic.imagetool.installer.InstallerType;
 import com.oracle.weblogic.imagetool.installer.MiddlewareInstall;
 import com.oracle.weblogic.imagetool.logging.LoggingFacade;
 import com.oracle.weblogic.imagetool.logging.LoggingFactory;
 import com.oracle.weblogic.imagetool.util.Constants;
-import com.oracle.weblogic.imagetool.util.DockerBuildCommand;
 import com.oracle.weblogic.imagetool.util.Utils;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
@@ -66,7 +66,7 @@ public class CreateImage extends CommonOptions implements Callable<CommandRespon
             install.copyFiles(cache(), tmpDir);
             dockerfileOptions.setMiddlewareInstall(install);
 
-            DockerBuildCommand cmdBuilder = getInitialBuildCmd(tmpDir);
+            BuildCommand cmdBuilder = getInitialBuildCmd(tmpDir);
             // build wdt args if user passes --wdtModelPath
             wdtOptions.handleWdtArgs(dockerfileOptions, cmdBuilder, tmpDir);
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
@@ -52,8 +52,6 @@ public class RebaseImage extends CommonOptions implements Callable<CommandRespon
         String newOracleHome = null;
         String newJavaHome = null;
         String domainHome;
-        String adminPort;
-        String managedServerPort;
 
         try {
 
@@ -74,9 +72,6 @@ public class RebaseImage extends CommonOptions implements Callable<CommandRespon
                 oldOracleHome = baseImageProperties.getProperty("ORACLE_HOME", null);
                 oldJavaHome = baseImageProperties.getProperty("JAVA_PATH", null);
                 domainHome = baseImageProperties.getProperty("DOMAIN_HOME", null);
-                adminPort = baseImageProperties.getProperty("ADMIN_PORT", null);
-                managedServerPort = baseImageProperties.getProperty("MANAGED_SERVER_PORT", null);
-
 
             } else {
                 return new CommandResponse(-1, "Source Image not set");
@@ -115,9 +110,6 @@ public class RebaseImage extends CommonOptions implements Callable<CommandRespon
             }
 
             BuildCommand cmdBuilder = getInitialBuildCmd(tmpDir);
-
-            cmdBuilder.buildArg("ADMIN_PORT", adminPort)
-                .buildArg("MANAGED_SERVER_PORT", managedServerPort);
 
             if (dockerfileOptions.isRebaseToNew()) {
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
@@ -69,7 +69,7 @@ public class RebaseImage extends CommonOptions implements Callable<CommandRespon
                 Utils.copyResourceAsFile("/probe-env/test-update-env.sh",
                     tmpDir + File.separator + "test-env.sh", true);
 
-                Properties baseImageProperties = Utils.getBaseImageProperties(sourceImage, tmpDir);
+                Properties baseImageProperties = Utils.getBaseImageProperties(buildEngine, sourceImage, tmpDir);
 
                 oldOracleHome = baseImageProperties.getProperty("ORACLE_HOME", null);
                 oldJavaHome = baseImageProperties.getProperty("JAVA_PATH", null);
@@ -91,7 +91,7 @@ public class RebaseImage extends CommonOptions implements Callable<CommandRespon
                 Utils.copyResourceAsFile("/probe-env/test-update-env.sh",
                     tmpDir + File.separator + "test-env.sh", true);
 
-                Properties baseImageProperties = Utils.getBaseImageProperties(targetImage, tmpDir);
+                Properties baseImageProperties = Utils.getBaseImageProperties(buildEngine, targetImage, tmpDir);
 
                 newOracleHome = baseImageProperties.getProperty("ORACLE_HOME", null);
                 newJavaHome = baseImageProperties.getProperty("JAVA_PATH", null);
@@ -165,7 +165,7 @@ public class RebaseImage extends CommonOptions implements Callable<CommandRespon
         } finally {
             if (!skipcleanup) {
                 Utils.deleteFilesRecursively(tmpDir);
-                Utils.removeIntermediateDockerImages(buildId);
+                Utils.removeIntermediateDockerImages(buildEngine, buildId);
             }
         }
         Instant endTime = Instant.now();

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
@@ -15,13 +15,13 @@ import java.util.concurrent.Callable;
 
 import com.oracle.weblogic.imagetool.api.model.CachedFile;
 import com.oracle.weblogic.imagetool.api.model.CommandResponse;
+import com.oracle.weblogic.imagetool.builder.BuildCommand;
 import com.oracle.weblogic.imagetool.installer.FmwInstallerType;
 import com.oracle.weblogic.imagetool.installer.InstallerType;
 import com.oracle.weblogic.imagetool.installer.MiddlewareInstall;
 import com.oracle.weblogic.imagetool.logging.LoggingFacade;
 import com.oracle.weblogic.imagetool.logging.LoggingFactory;
 import com.oracle.weblogic.imagetool.util.Constants;
-import com.oracle.weblogic.imagetool.util.DockerBuildCommand;
 import com.oracle.weblogic.imagetool.util.DockerfileOptions;
 import com.oracle.weblogic.imagetool.util.Utils;
 import picocli.CommandLine.Command;
@@ -114,7 +114,7 @@ public class RebaseImage extends CommonOptions implements Callable<CommandRespon
                 return new CommandResponse(-1, Utils.getMessage("IMG-0025"));
             }
 
-            DockerBuildCommand cmdBuilder = getInitialBuildCmd(tmpDir);
+            BuildCommand cmdBuilder = getInitialBuildCmd(tmpDir);
 
             cmdBuilder.buildArg("ADMIN_PORT", adminPort)
                 .buildArg("MANAGED_SERVER_PORT", managedServerPort);

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -14,12 +14,12 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 
 import com.oracle.weblogic.imagetool.api.model.CommandResponse;
+import com.oracle.weblogic.imagetool.builder.BuildCommand;
 import com.oracle.weblogic.imagetool.cachestore.OPatchFile;
 import com.oracle.weblogic.imagetool.installer.FmwInstallerType;
 import com.oracle.weblogic.imagetool.logging.LoggingFacade;
 import com.oracle.weblogic.imagetool.logging.LoggingFactory;
 import com.oracle.weblogic.imagetool.util.Constants;
-import com.oracle.weblogic.imagetool.util.DockerBuildCommand;
 import com.oracle.weblogic.imagetool.util.Utils;
 import com.oracle.weblogic.imagetool.wdt.WdtOperation;
 import picocli.CommandLine.ArgGroup;
@@ -144,7 +144,7 @@ public class UpdateImage extends CommonOptions implements Callable<CommandRespon
                 }
             }
 
-            DockerBuildCommand cmdBuilder = getInitialBuildCmd(tmpDir);
+            BuildCommand cmdBuilder = getInitialBuildCmd(tmpDir);
 
             // build wdt args if user passes --wdtModelPath
             wdtOptions.handleWdtArgs(dockerfileOptions, cmdBuilder, tmpDir);

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -60,7 +60,7 @@ public class UpdateImage extends CommonOptions implements Callable<CommandRespon
             Utils.copyResourceAsFile("/probe-env/test-update-env.sh",
                 tmpDir + File.separator + "test-env.sh", true);
 
-            Properties baseImageProperties = Utils.getBaseImageProperties(fromImage, tmpDir);
+            Properties baseImageProperties = Utils.getBaseImageProperties(buildEngine, fromImage, tmpDir);
 
             dockerfileOptions.setJavaHome(baseImageProperties.getProperty("JAVA_HOME", null));
 
@@ -172,7 +172,7 @@ public class UpdateImage extends CommonOptions implements Callable<CommandRespon
         } finally {
             if (!skipcleanup) {
                 Utils.deleteFilesRecursively(tmpDir);
-                Utils.removeIntermediateDockerImages(buildId);
+                Utils.removeIntermediateDockerImages(buildEngine, buildId);
             }
         }
         Instant endTime = Instant.now();

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/WdtOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/WdtOptions.java
@@ -12,10 +12,10 @@ import java.util.Collections;
 import java.util.List;
 
 import com.oracle.weblogic.imagetool.api.model.CachedFile;
+import com.oracle.weblogic.imagetool.builder.BuildCommand;
 import com.oracle.weblogic.imagetool.installer.InstallerType;
 import com.oracle.weblogic.imagetool.logging.LoggingFacade;
 import com.oracle.weblogic.imagetool.logging.LoggingFactory;
-import com.oracle.weblogic.imagetool.util.DockerBuildCommand;
 import com.oracle.weblogic.imagetool.util.DockerfileOptions;
 import com.oracle.weblogic.imagetool.util.DomainHomeSourceType;
 import com.oracle.weblogic.imagetool.util.ResourceTemplateOptions;
@@ -52,7 +52,7 @@ public class WdtOptions {
      * @param tmpDir the tmp directory which is passed to docker as the build context directory
      * @throws IOException in case of error
      */
-    void handleWdtArgs(DockerfileOptions dockerfileOptions, DockerBuildCommand cmdBuilder, String tmpDir)
+    void handleWdtArgs(DockerfileOptions dockerfileOptions, BuildCommand cmdBuilder, String tmpDir)
         throws IOException {
 
         if (!isUsingWdt()) {

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/WdtOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/WdtOptions.java
@@ -62,8 +62,7 @@ public class WdtOptions {
         logger.entering(tmpDir);
         String encryptionKey = Utils.getPasswordFromInputs(encryptionKeyStr, encryptionKeyFile, encryptionKeyEnv);
         if (encryptionKey != null) {
-            dockerfileOptions.setWdtUseEncryption(true);
-            cmdBuilder.buildArg("WDT_ENCRYPTION_KEY", encryptionKey, true);
+            dockerfileOptions.setWdtEncryptionKey(encryptionKey);
         }
 
         dockerfileOptions.setWdtEnabled()

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
@@ -287,7 +287,7 @@ public class Utils {
                 stringBuilder.append(line);
                 stringBuilder.append(System.lineSeparator());
             }
-            throw new IOException(Utils.getMessage("IMG-0089", stringBuilder));
+            throw new IOException(Utils.getMessage("IMG-0088", stringBuilder));
         }
     }
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
@@ -287,7 +287,7 @@ public class Utils {
                 stringBuilder.append(line);
                 stringBuilder.append(System.lineSeparator());
             }
-            throw new IOException("docker command failed with error: " + stringBuilder.toString());
+            throw new IOException(Utils.getMessage("IMG-0089", stringBuilder));
         }
     }
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
@@ -419,11 +419,11 @@ public class Utils {
      * @throws IOException          when the Docker command fails
      * @throws InterruptedException when the Docker command is interrupted
      */
-    public static Properties getBaseImageProperties(String dockerImage, String tmpDir)
+    public static Properties getBaseImageProperties(String builder, String dockerImage, String tmpDir)
         throws IOException, InterruptedException {
 
         logger.entering(dockerImage, tmpDir);
-        List<String> imageEnvCmd = Utils.getDockerRunCmd(tmpDir, dockerImage, "test-env.sh");
+        List<String> imageEnvCmd = Utils.getDockerRunCmd(builder, tmpDir, dockerImage, "test-env.sh");
         Properties result = Utils.runDockerCommand(imageEnvCmd);
         logger.exiting(result);
         return result;
@@ -432,14 +432,15 @@ public class Utils {
     /**
      * Constructs a docker command to run a script in the container with a volume mount.
      *
+     * @param builder        docker/podman executable
      * @param hostDirToMount host dir
      * @param dockerImage    docker image tag
      * @param scriptToRun    script to execute on the container
      * @param args           args to the script
      * @return command
      */
-    private static List<String> getDockerRunCmd(String hostDirToMount, String dockerImage, String scriptToRun,
-                                               String... args) throws IOException {
+    private static List<String> getDockerRunCmd(String builder, String hostDirToMount, String dockerImage,
+                                                String scriptToRun, String... args) throws IOException {
 
         // We are removing the volume mount option, -v won't work in remote docker daemon and also
         // problematic if the mounted volume source is on a nfs volume as we have no idea what the docker volume
@@ -453,7 +454,7 @@ public class Utils {
         String oneCommand = String.format("echo %s | base64 -d | /bin/bash", encodedFile);
         logger.finer("ONE COMMAND [" + oneCommand + "]");
         final List<String> retVal = Stream.of(
-            "docker", "run", "--rm",
+            builder, "run", "--rm",
             dockerImage, "/bin/bash", "-c", oneCommand).collect(Collectors.toList());
         if (args != null && args.length > 0) {
             retVal.addAll(Arrays.asList(args));
@@ -738,14 +739,16 @@ public class Utils {
 
     /**
      * Remove the intermediate images created by the multi-stage Docker build.
+     * @param builder docker/podman executable
      * @param buildId the build ID used to identify the images created during this build.
      * @throws IOException if the external Docker command fails.
      * @throws InterruptedException if this program was interrupted waiting on the Docker command.
      */
-    public static void removeIntermediateDockerImages(String buildId) throws IOException, InterruptedException {
+    public static void removeIntermediateDockerImages(String builder, String buildId)
+        throws IOException, InterruptedException {
         logger.entering();
         final List<String> command = Stream.of(
-            "docker", "image", "prune", "-f", "--filter", "label=com.oracle.weblogic.imagetool.buildid=" + buildId)
+            builder, "image", "prune", "-f", "--filter", "label=com.oracle.weblogic.imagetool.buildid=" + buildId)
             .collect(Collectors.toList());
         Properties result = runDockerCommand(command);
         logger.fine("Intermediate images removed: {0}", result.get("Total"));

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
@@ -277,7 +277,7 @@ public class Utils {
      * @param process the Docker process
      * @throws IOException if an error occurs while reading standard error (stderr) from the Docker build.
      */
-    static void processError(Process process) throws IOException {
+    public static void processError(Process process) throws IOException {
         try (
             BufferedReader stderr = new BufferedReader(new InputStreamReader(process.getErrorStream()))
         ) {

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -86,3 +86,4 @@ IMG-0084=No recommended patches found for {0}
 IMG-0085=The recommended ADR patch was skipped for the WLS installer, use --patch {0} to apply this patch
 IMG-0086=Failed to find patch number [[brightred: {0}]] on Oracle servers, verify the patch number is correct using My Oracle Support.
 IMG-0087=The Oracle Home directory in --fromImage={0} has an owner and group of {1}:{2}.  You must update the image with the same user and group setting from when it was created. Example: --chown={1}:{2}
+IMG-0088=Build command failed with error: {0}

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -1,7 +1,7 @@
 IMG-0000=JAVA_HOME detected in base image, skipping JDK install: {0}
 IMG-0001=[[yellow: {0} - there are no recommended PSUs for version {1}]]
 IMG-0002=User specified fromImage {0}
-IMG-0003=Temporary directory used for docker build context: {0}
+IMG-0003=Temporary directory used for image build context: {0}
 IMG-0004=Invalid patch id {0}. The patch id must be in the format of {1}.  Where the first part is the 8 digit patch ID, and the second half, after the underscore, is the release version for the patch. The release version needs to be specified with 5 places such as 12.2.1.3.0 or 12.2.1.3.190416. Release version is required when adding a patch to the cache or when multiple versions of the same patch number exist for different versions.
 IMG-0005=Installer response file: {0}
 IMG-0006=No patch conflicts detected
@@ -76,7 +76,7 @@ IMG-0074=OPatch will not be updated, fromImage has version {0}, available versio
 IMG-0075=Nothing to do, cache entry already exists
 IMG-0076=Invalid argument, the value provided for {0} is invalid or empty.
 IMG-0077=Skipping duplicate patch {0}. Patch file already exists in the build context folder. Did you accidentally list the patch twice?
-IMG-0078=REMOVED
+IMG-0078=Starting build: {0}
 IMG-0079=OS Package Manager override, changed from {0} to {1}
 IMG-0080=Argument {0} does not match any FmwInstallerType names
 IMG-0081=Unable to retrieve list of Oracle releases from Oracle Updates (ARU). Try again later.

--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -147,7 +147,6 @@ RUN cd {{{tempDir}}}/opatch \
 
 {{#isWdtEnabled}}
     FROM wls_build as wdt_build
-    ARG WDT_ENCRYPTION_KEY
     LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
     ENV WLSDEPLOY_PROPERTIES="{{{wlsdeploy_properties}}} -Djava.security.egd=file:/dev/./urandom" \
@@ -183,7 +182,7 @@ RUN cd {{{tempDir}}}/opatch \
     RUN unzip -q {{{tempDir}}}/{{{wdtInstaller}}} -d {{{wdt_home}}}
     {{^modelOnly}}
         RUN cd {{{wdt_home}}}/weblogic-deploy/bin \
-        && {{#isWdtUseEncryption}}echo $WDT_ENCRYPTION_KEY | {{/isWdtUseEncryption}} ./createDomain.sh \
+        && {{#isWdtUseEncryption}}echo {{{wdtEncryptionKey}}} | {{/isWdtUseEncryption}} ./createDomain.sh \
         -oracle_home {{{oracle_home}}} \
         -domain_home {{{domain_home}}} \
         -domain_type {{domainType}} \

--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -217,21 +217,11 @@ RUN cd {{{tempDir}}}/opatch \
 
 FROM os_update as final_build
 
-ARG ADMIN_NAME
-ARG ADMIN_HOST
-ARG ADMIN_PORT
-ARG MANAGED_SERVER_PORT
-
 ENV ORACLE_HOME={{{oracle_home}}} \
 {{#installJava}}
     JAVA_HOME={{{java_home}}} \
 {{/installJava}}
 {{#isWdtEnabled}}
-    ADMIN_NAME=${ADMIN_NAME:-admin-server} \
-    ADMIN_HOST=${ADMIN_HOST:-wlsadmin} \
-    ADMIN_PORT=${ADMIN_PORT:-7001} \
-    MANAGED_SERVER_NAME=${MANAGED_SERVER_NAME:-} \
-    MANAGED_SERVER_PORT=${MANAGED_SERVER_PORT:-8001} \
     DOMAIN_HOME={{{domain_home}}} \
 {{/isWdtEnabled}}
     PATH=${PATH}:{{{java_home}}}/bin:{{{oracle_home}}}/oracle_common/common/bin:{{{oracle_home}}}/wlserver/common/bin:{{{oracle_home}}}{{#isWdtEnabled}}:${{{domain_home}}}/bin{{/isWdtEnabled}}
@@ -267,11 +257,6 @@ COPY --from=wls_build --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle
         COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{{domain_home}}} {{{domain_home}}}/
         RUN chmod g+w {{{domain_home}}}
     {{/modelOnly}}
-{{/isWdtEnabled}}
-
-{{#isWdtEnabled}}
-    # Expose admin server, managed server port
-    EXPOSE $ADMIN_PORT $MANAGED_SERVER_PORT
 {{/isWdtEnabled}}
 
 USER {{userid}}

--- a/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
@@ -170,8 +170,6 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
     FROM os_update as final_build
 
-    ARG ADMIN_NAME
-    ARG ADMIN_HOST
     ARG ADMIN_PORT
     ARG MANAGED_SERVER_PORT
 

--- a/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
@@ -8,24 +8,16 @@
 {{#isRebaseToTarget}}
 FROM {{sourceImage}} as source_image
 FROM {{targetImage}} as final_build
-ARG ADMIN_PORT
-ARG MANAGED_SERVER_PORT
 
-ENV ADMIN_PORT=${ADMIN_PORT} \
-    MANAGED_SERVER_PORT=${MANAGED_SERVER_PORT} \
-    DOMAIN_HOME={{{domain_home}}}
+ENV DOMAIN_HOME={{{domain_home}}}
 LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
 {{/isRebaseToTarget}}
 {{#isRebaseToNew}}
     FROM {{sourceImage}} as source_image
     FROM {{baseImage}} as os_update
-    ARG ADMIN_PORT
-    ARG MANAGED_SERVER_PORT
 
-    ENV ADMIN_PORT=${ADMIN_PORT} \
-        MANAGED_SERVER_PORT=${MANAGED_SERVER_PORT} \
-        DOMAIN_HOME={{{domain_home}}}
+    ENV DOMAIN_HOME={{{domain_home}}}
 
     LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
     USER root
@@ -170,9 +162,6 @@ LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 
     FROM os_update as final_build
 
-    ARG ADMIN_PORT
-    ARG MANAGED_SERVER_PORT
-
     ENV ORACLE_HOME={{{oracle_home}}} \
     {{#installJava}}
         JAVA_HOME={{{java_home}}} \
@@ -199,7 +188,6 @@ RUN mkdir -p {{domain_home}}
 COPY --from=source_image --chown={{userid}}:{{groupid}} {{domain_home}} {{domain_home}}/
 RUN chmod g+w {{{domain_home}}}
 
-EXPOSE $ADMIN_PORT $MANAGED_SERVER_PORT
 WORKDIR {{{work_dir}}}
 
 {{#finalBuildCommands}}

--- a/imagetool/src/main/resources/docker-files/Update_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Update_Image.mustache
@@ -86,12 +86,7 @@ USER root
 ENV OPATCH_NO_FUSER=true
 
 {{#isWdtEnabled}}
-ENV ADMIN_NAME=${ADMIN_NAME:-admin-server} \
-    ADMIN_HOST=${ADMIN_HOST:-wlsadmin} \
-    ADMIN_PORT=${ADMIN_PORT:-7001} \
-    MANAGED_SERVER_NAME=${MANAGED_SERVER_NAME:-} \
-    MANAGED_SERVER_PORT=${MANAGED_SERVER_PORT:-8001} \
-    DOMAIN_HOME={{{domain_home}}} \
+ENV DOMAIN_HOME={{{domain_home}}} \
     PATH=${PATH}:{{{domain_home}}}/bin
 {{/isWdtEnabled}}
 

--- a/imagetool/src/main/resources/probe-env/test-update-env.sh
+++ b/imagetool/src/main/resources/probe-env/test-update-env.sh
@@ -27,8 +27,6 @@ fi
 if [[ -n "$JAVA_HOME" ]]; then
   echo JAVA_HOME="$JAVA_HOME"
   echo JAVA_PATH="$(readlink -f $JAVA_HOME)"
-  echo ADMIN_PORT="${ADMIN_PORT}"
-  echo MANAGED_SERVER_PORT="${MANAGED_SERVER_PORT}"
 fi
 
 if [[ -n "$ORACLE_HOME" ]]; then

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <packaging>pom</packaging>
 
     <name>WebLogic Image Tool</name>
-    <description>Build Docker images with a specific WebLogic install and Java version.</description>
+    <description>Build images with a specific WebLogic install and Java version.</description>
     <url>https://github.com/oracle/weblogic-image-tool</url>
     <inceptionYear>2019</inceptionYear>
     <licenses>

--- a/site/create-image-with-internet.md
+++ b/site/create-image-with-internet.md
@@ -49,7 +49,7 @@ You will see the Docker command output as the tool runs:
 ```bash
 [2019-05-28 10:37:02] [com.oracle.weblogic.imagetool.cli.menu.CreateImage] [INFO   ] tmp directory used for build
 context: /home/acmeuser/wlsimgbuilder_temp8791654163579491583
-[2019-05-28 10:37:09] [com.oracle.weblogic.imagetool.cli.menu.CreateImage] [INFO   ] docker cmd = docker build
+[2019-05-28 10:37:09] [com.oracle.weblogic.imagetool.cli.menu.CreateImage] [INFO   ] Starting build: docker build
 --force-rm --rm=true --no-cache --tag wls:12.2.1.3.0 --build-arg http_proxy=http://company-proxy.com:80 --build-arg
 https_proxy=http://company-proxy.com:80 --build-arg WLS_PKG=fmw_12.2.1.3.0_wls_Disk1_1of1.zip --build-arg
 JAVA_PKG=jdk-8u201-linux-x64.tar.gz --build-arg PATCHDIR=patches /home/acmeuser/wlsimgbuilder_temp8791654163579491583


### PR DESCRIPTION
Removed hard references to Docker and replaced with value provided by the command line.  The default value provides the same behavior as previously used in the hard references `docker`.