### PR TITLE
when reinstalling WDT with UPDATE, delete old version first

### DIFF
--- a/imagetool/src/main/resources/docker-files/Update_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Update_Image.mustache
@@ -42,7 +42,8 @@
         {{{.}}}
     {{/beforeWdtCommand}}
 
-    RUN cd {{{wdt_home}}} \
+    RUN rm -rf {{{wdt_home}}}/weblogic-deploy \
+    && cd {{{wdt_home}}} \
     && jar xf {{{tempDir}}}/{{{wdtInstaller}}} \
     && cd weblogic-deploy/bin \
     && rm ./*.cmd \


### PR DESCRIPTION
For older versions of WIT, the compiled python classes were not completely removed.  To prevent issues when updating images created with older versions of Image Tool, this fix completely cleans up the WDT install folder before expanding the new installer for imagetool UPDATE.