### PR TITLE
new inspect image tool

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/ImageTool.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/ImageTool.java
@@ -9,6 +9,7 @@ import java.util.concurrent.Callable;
 import com.oracle.weblogic.imagetool.api.model.CommandResponse;
 import com.oracle.weblogic.imagetool.cli.cache.CacheCLI;
 import com.oracle.weblogic.imagetool.cli.menu.CreateImage;
+import com.oracle.weblogic.imagetool.cli.menu.InspectImage;
 import com.oracle.weblogic.imagetool.cli.menu.RebaseImage;
 import com.oracle.weblogic.imagetool.cli.menu.UpdateImage;
 import com.oracle.weblogic.imagetool.logging.LoggingFacade;
@@ -29,6 +30,7 @@ import picocli.CommandLine.ParseResult;
                 CreateImage.class,
                 UpdateImage.class,
                 RebaseImage.class,
+                InspectImage.class,
                 HelpCommand.class
         },
         requiredOptionMarker = '*',

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -356,10 +356,8 @@ public abstract class CommonOptions {
             logger.finer("IMG-0002", fromImage);
             dockerfileOptions.setBaseImage(fromImage);
 
-            Utils.copyResourceAsFile("/probe-env/test-create-env.sh",
-                tmpDir + File.separator + "test-env.sh", true);
-
-            Properties baseImageProperties = Utils.getBaseImageProperties(buildEngine, fromImage, tmpDir);
+            Properties baseImageProperties = Utils.getBaseImageProperties(buildEngine, fromImage,
+                "/probe-env/test-create-env.sh", tmpDir);
 
             if (baseImageProperties.getProperty("WLS_VERSION", null) != null) {
                 throw new IllegalArgumentException(Utils.getMessage("IMG-0038", fromImage,

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/InspectImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/InspectImage.java
@@ -1,0 +1,100 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.weblogic.imagetool.cli.menu;
+
+import java.io.BufferedWriter;
+import java.io.OutputStreamWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
+import java.util.concurrent.Callable;
+
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheFactory;
+import com.github.mustachejava.util.DecoratedCollection;
+import com.oracle.weblogic.imagetool.api.model.CommandResponse;
+import com.oracle.weblogic.imagetool.util.Utils;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "inspect",
+    description = "Inspect an image created by this tool",
+    requiredOptionMarker = '*',
+    abbreviateSynopsis = true
+)
+public class InspectImage implements Callable<CommandResponse> {
+    @Override
+    public CommandResponse call() throws Exception {
+        Path tmpDir = Files.createTempDirectory(Paths.get(Utils.getBuildWorkingDir()), "wlsimgbuilder_temp");
+        String tempDirectory = tmpDir.toAbsolutePath().toString();
+
+        String scriptToRun = "/probe-env/inspect-image.sh";
+        // add additional formats here, the ENUM, and to the resources/inspect-responses folder
+        if (listPatches) {
+            scriptToRun = "/probe-env/inspect-image-long.sh";
+        }
+
+        Properties baseImageProperties =
+            Utils.getBaseImageProperties(buildEngine, imageName, scriptToRun, tempDirectory);
+        MustacheFactory mf = new DefaultMustacheFactory("inspect-responses");
+
+        String outputTemplate;
+        // add additional formats here, the ENUM, and to the resources/inspect-responses folder
+        switch (ouptutFormat) {
+            case JSON:
+            default:
+                outputTemplate = "inspect-json.mustache";
+        }
+        Mustache mustache = mf.compile(outputTemplate);
+
+        // sort the output alphabetically for easier readability
+        TreeMap<String,String> sortedSet = new TreeMap<>();
+        for (Map.Entry<Object,Object> x: baseImageProperties.entrySet()) {
+            sortedSet.put(x.getKey().toString(), x.getValue().toString());
+        }
+
+        try (BufferedWriter out = new BufferedWriter(new OutputStreamWriter(System.out))) {
+            // create a decorated collection so that the output template can utilize "last" (last collection item)
+            mustache.execute(out, new Object() {
+                @SuppressWarnings("unused")
+                final DecoratedCollection<Map.Entry<String, String>> response =
+                    new DecoratedCollection<>(sortedSet.entrySet());
+            }).flush();
+        }
+        return new CommandResponse(0, "");
+    }
+
+    @CommandLine.Option(
+        names = {"--image", "-i"},
+        required = true,
+        paramLabel = "IMAGE:ID",
+        description = "Image ID or image name to be inspected"
+    )
+    private String imageName;
+
+    @CommandLine.Option(
+        names = {"--builder", "-b"},
+        description = "Executable to inspect docker images. Default: ${DEFAULT-VALUE}"
+    )
+    String buildEngine = "docker";
+
+    @CommandLine.Option(
+        names = {"--patches"},
+        description = "Include OPatch information in the output, including a list of patches applied.",
+        defaultValue = "false"
+    )
+    private boolean listPatches;
+
+    @CommandLine.Option(
+        names = {"--format"},
+        paramLabel = "FORMAT",
+        description = "Output format. Supported values: ${COMPLETION-CANDIDATES} Default: ${DEFAULT-VALUE}",
+        defaultValue = "JSON"
+    )
+    private OutputFormat ouptutFormat;
+}

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/OutputFormat.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/OutputFormat.java
@@ -1,0 +1,8 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.weblogic.imagetool.cli.menu;
+
+public enum OutputFormat {
+    JSON
+}

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
@@ -65,12 +65,9 @@ public class RebaseImage extends CommonOptions implements Callable<CommandRespon
                 logger.finer("IMG-0002", sourceImage);
                 dockerfileOptions.setSourceImage(sourceImage);
 
-                // Get source image
-                Utils.copyResourceAsFile("/probe-env/test-update-env.sh",
-                    tmpDir + File.separator + "test-env.sh", true);
-
                 logger.info("IMG-0091", sourceImage);
-                Properties baseImageProperties = Utils.getBaseImageProperties(buildEngine, sourceImage, tmpDir);
+                Properties baseImageProperties = Utils.getBaseImageProperties(buildEngine, sourceImage,
+                    "/probe-env/test-update-env.sh", tmpDir);
 
                 oldOracleHome = baseImageProperties.getProperty("ORACLE_HOME", null);
                 oldJavaHome = baseImageProperties.getProperty("JAVA_PATH", null);
@@ -85,11 +82,9 @@ public class RebaseImage extends CommonOptions implements Callable<CommandRespon
                 logger.finer("IMG-0002", targetImage);
                 dockerfileOptions.setTargetImage(targetImage);
                 dockerfileOptions.setRebaseToTarget(true);
-                // Get source image
-                Utils.copyResourceAsFile("/probe-env/test-update-env.sh",
-                    tmpDir + File.separator + "test-env.sh", true);
 
-                Properties baseImageProperties = Utils.getBaseImageProperties(buildEngine, targetImage, tmpDir);
+                Properties baseImageProperties = Utils.getBaseImageProperties(buildEngine, targetImage,
+                    "/probe-env/test-update-env.sh", tmpDir);
 
                 newOracleHome = baseImageProperties.getProperty("ORACLE_HOME", null);
                 newJavaHome = baseImageProperties.getProperty("JAVA_PATH", null);

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -57,10 +57,8 @@ public class UpdateImage extends CommonOptions implements Callable<CommandRespon
 
             tmpDir = getTempDirectory();
 
-            Utils.copyResourceAsFile("/probe-env/test-update-env.sh",
-                tmpDir + File.separator + "test-env.sh", true);
-
-            Properties baseImageProperties = Utils.getBaseImageProperties(buildEngine, fromImage, tmpDir);
+            Properties baseImageProperties = Utils.getBaseImageProperties(buildEngine, fromImage,
+                "/probe-env/test-update-env.sh", tmpDir);
 
             dockerfileOptions.setJavaHome(baseImageProperties.getProperty("JAVA_HOME", null));
 

--- a/imagetool/src/main/resources/inspect-responses/inspect-json.mustache
+++ b/imagetool/src/main/resources/inspect-responses/inspect-json.mustache
@@ -1,0 +1,5 @@
+{
+{{#response}}
+  {{value.key}}: "{{value.value}}"{{^last}}, {{/last}}
+{{/response}}
+}

--- a/imagetool/src/main/resources/probe-env/inspect-image-long.sh
+++ b/imagetool/src/main/resources/probe-env/inspect-image-long.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+#Copyright (c) 2021, Oracle and/or its affiliates.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+for token in $(java -version 2>&1)
+do
+  if [[ $token =~ \"([[:digit:]])\.([[:digit:]])\.(.*)\" ]]
+  then
+    echo javaVersion="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+  fi
+done
+
+if command -v dnf &> /dev/null; then
+  echo packageManager=dnf
+elif command -v yum &> /dev/null; then
+  echo packageManager=yum
+elif command -v microdnf &> /dev/null; then
+  echo packageManager=microdnf
+elif command -v apt-get &> /dev/null; then
+  echo packageManager=aptget
+elif command -v apk &> /dev/null; then
+  echo packageManager=apk
+elif command -v zypper &> /dev/null; then
+  echo packageManager=zypper
+fi
+
+if [[ -n "$JAVA_HOME" ]]; then
+  echo javaHome="$JAVA_HOME"
+fi
+
+if [[ -n "$ORACLE_HOME" ]]; then
+  echo oracleHome="$ORACLE_HOME"
+  WLS_TYPE=$(cat "$ORACLE_HOME"/inventory/registry.xml 2> /dev/null | grep -q 'WebLogic Server for FMW' && printf "fmw")
+  if [[ -n "$WLS_TYPE" ]]; then
+    echo wlsType="$WLS_TYPE"
+  fi
+  if [[ -n "$JAVA_HOME" ]]; then
+    echo wlsVersion="$("$JAVA_HOME"/bin/java -cp "$ORACLE_HOME"/wlserver/server/lib/weblogic.jar weblogic.version 2> /dev/null | grep -oE -m 1 '([[:digit:]\.]+)' | head -1)"
+  fi
+  echo oracleHomeUser="$(stat -c '%U' "$ORACLE_HOME")"
+  echo oracleHomeGroup="$(stat -c '%G' "$ORACLE_HOME")"
+
+  echo opatchVersion="$("$ORACLE_HOME"/OPatch/opatch version 2> /dev/null | grep -oE -m 1 '([[:digit:]\.]+)')"
+  echo oraclePatches=$("$ORACLE_HOME"/OPatch/opatch lspatches | awk -F";" '/^[0-9]/ {print $0";"}')
+fi
+
+if [[ -n "$DOMAIN_HOME" ]]; then
+  echo domainHome="$DOMAIN_HOME"
+  if [[ ! -d "$DOMAIN_HOME" ]] || [[ -z "$(ls -A $DOMAIN_HOME)" ]]; then
+    echo wdtModelOnly=true
+  fi
+fi
+
+if [[ -n "$WDT_MODEL_HOME" ]]; then
+  echo wdtModelHome="$WDT_MODEL_HOME"
+fi

--- a/imagetool/src/main/resources/probe-env/inspect-image.sh
+++ b/imagetool/src/main/resources/probe-env/inspect-image.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+#Copyright (c) 2021, Oracle and/or its affiliates.
+#
+#Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+for token in $(java -version 2>&1)
+do
+  if [[ $token =~ \"([[:digit:]])\.([[:digit:]])\.(.*)\" ]]
+  then
+    echo javaVersion="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+  fi
+done
+
+if command -v dnf &> /dev/null; then
+  echo packageManager=dnf
+elif command -v yum &> /dev/null; then
+  echo packageManager=yum
+elif command -v microdnf &> /dev/null; then
+  echo packageManager=microdnf
+elif command -v apt-get &> /dev/null; then
+  echo packageManager=aptget
+elif command -v apk &> /dev/null; then
+  echo packageManager=apk
+elif command -v zypper &> /dev/null; then
+  echo packageManager=zypper
+fi
+
+if [[ -n "$JAVA_HOME" ]]; then
+  echo javaHome="$JAVA_HOME"
+fi
+
+if [[ -n "$ORACLE_HOME" ]]; then
+  echo oracleHome="$ORACLE_HOME"
+  WLS_TYPE=$(cat "$ORACLE_HOME"/inventory/registry.xml 2> /dev/null | grep -q 'WebLogic Server for FMW' && printf "fmw")
+  if [[ -n "$WLS_TYPE" ]]; then
+    echo wlsType="$WLS_TYPE"
+  fi
+  if [[ -n "$JAVA_HOME" ]]; then
+    echo wlsVersion="$("$JAVA_HOME"/bin/java -cp "$ORACLE_HOME"/wlserver/server/lib/weblogic.jar weblogic.version 2> /dev/null | grep -oE -m 1 '([[:digit:]\.]+)' | head -1)"
+  fi
+
+  echo oracleHomeUser="$(stat -c '%U' "$ORACLE_HOME")"
+  echo oracleHomeGroup="$(stat -c '%G' "$ORACLE_HOME")"
+fi
+
+if [[ -n "$DOMAIN_HOME" ]]; then
+  echo domainHome="$DOMAIN_HOME"
+  if [[ ! -d "$DOMAIN_HOME" ]] || [[ -z "$(ls -A $DOMAIN_HOME)" ]]; then
+    echo wdtModelOnly=true
+  fi
+fi
+
+if [[ -n "$WDT_MODEL_HOME" ]]; then
+  echo wdtModelHome="$WDT_MODEL_HOME"
+fi


### PR DESCRIPTION
Added a new verb to the image tool that makes is simpler to query a create image for its contents, such as Java version, WebLogic version, WebLogic patches, etc.

``` bash
$ imagetool inspect --image d:12213
{
  javaHome: "/u01/jdk", 
  javaVersion: "1.8.0_241", 
  oracleHome: "/u01/oracle", 
  oracleHomeGroup: "oracle", 
  oracleHomeUser: "oracle", 
  packageManager: "yum", 
  wlsVersion: "12.2.1.3.0"
}
```