### PR TITLE
Added FMW Platform and Java Require Files ARU product IDs

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruProduct.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruProduct.java
@@ -9,6 +9,8 @@ package com.oracle.weblogic.imagetool.aru;
 public enum AruProduct {
     WLS("15991", "Oracle WebLogic Server"),
     COH("13964", "Oracle Coherence"),
+    JRF("10120", "Oracle Java Required Files"),
+    FMWPLAT("27638", "FMW Platform"),
     OSB("16011", "Oracle Service Bus"),
     SOA("12745", "Oracle SOA Suite"),
     B2B("12745", "Oracle B2B"),
@@ -22,8 +24,8 @@ public enum AruProduct {
     //FIT("33256", "Fusion Internal Tools") No longer used after July 2020 PSU
     ;
 
-    private String productId;
-    private String description;
+    private final String productId;
+    private final String description;
     AruProduct(String productId, String description) {
         this.productId = productId;
         this.description = description;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruUtil.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruUtil.java
@@ -156,7 +156,7 @@ public class AruUtil {
             List<AruPatch> patches = AruPatch.getPatches(aruRecommendations);
             String psuVersion = getPsuVersion(patches);
             if (!Utils.isEmptyString(psuVersion)) {
-                patches.forEach(p -> logger.fine("Discarding recommended patch {1} {2}", p.patchId(), p.description()));
+                patches.forEach(p -> logger.fine("Discarding recommended patch {0} {1}", p.patchId(), p.description()));
                 logger.fine("Recommended patch list contains a PSU, getting recommendations for PSU version {0}",
                     psuVersion);
                 // get release number for PSU

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
@@ -27,7 +27,7 @@ public enum FmwInstallerType {
     WLS(Arrays.asList(AruProduct.WLS, AruProduct.COH),
         InstallerType.WLS),
     // Oracle WebLogic Server Infrastructure (JRF)
-    FMW(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.JDEV),
+    FMW(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.JRF, AruProduct.FMWPLAT, AruProduct.JDEV),
         InstallerType.FMW),
     // Oracle Service Bus
     OSB(Utils.list(FMW.products, AruProduct.OSB),
@@ -70,8 +70,8 @@ public enum FmwInstallerType {
         InstallerType.FMW, InstallerType.WCS)
     ;
 
-    private InstallerType[] installers;
-    private List<AruProduct> products;
+    private final InstallerType[] installers;
+    private final List<AruProduct> products;
     FmwInstallerType(List<AruProduct> products, InstallerType... installers) {
         this.installers = installers;
         this.products = products;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
@@ -20,14 +20,15 @@ public enum FmwInstallerType {
     // data from https://updates.oracle.com/Orion/Services/metadata?table=aru_products
 
     // Oracle WebLogic Server
-    WLSSLIM(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT),
-        InstallerType.WLSSLIM),
-    WLSDEV(Arrays.asList(AruProduct.WLS, AruProduct.COH),
-        InstallerType.WLSDEV),
     WLS(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT),
         InstallerType.WLS),
+    WLSSLIM(Utils.list(WLS.products),
+        InstallerType.WLSSLIM),
+    WLSDEV(Utils.list(WLS.products),
+        InstallerType.WLSDEV),
+
     // Oracle WebLogic Server Infrastructure (JRF)
-    FMW(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.JRF, AruProduct.FMWPLAT, AruProduct.JDEV),
+    FMW(Utils.list(WLS.products, AruProduct.JRF, AruProduct.JDEV),
         InstallerType.FMW),
     // Oracle Service Bus
     OSB(Utils.list(FMW.products, AruProduct.OSB),

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
@@ -20,7 +20,7 @@ public enum FmwInstallerType {
     // data from https://updates.oracle.com/Orion/Services/metadata?table=aru_products
 
     // Oracle WebLogic Server
-    WLSSLIM(Arrays.asList(AruProduct.WLS, AruProduct.COH),
+    WLSSLIM(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT),
         InstallerType.WLSSLIM),
     WLSDEV(Arrays.asList(AruProduct.WLS, AruProduct.COH),
         InstallerType.WLSDEV),

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
@@ -24,7 +24,7 @@ public enum FmwInstallerType {
         InstallerType.WLSSLIM),
     WLSDEV(Arrays.asList(AruProduct.WLS, AruProduct.COH),
         InstallerType.WLSDEV),
-    WLS(Arrays.asList(AruProduct.WLS, AruProduct.COH),
+    WLS(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT),
         InstallerType.WLS),
     // Oracle WebLogic Server Infrastructure (JRF)
     FMW(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.JRF, AruProduct.FMWPLAT, AruProduct.JDEV),

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/aru/AruUtilTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/aru/AruUtilTest.java
@@ -104,7 +104,7 @@ class AruUtilTest {
 
         // if no recommended patches are found, method should return an empty list (test data does not have 12.2.1.4)
         recommendedPatches =
-            AruUtil.rest().getRecommendedPatches(FmwInstallerType.WLSDEV, "12.2.1.4.0", "x", "x");
+            AruUtil.rest().getRecommendedPatches(FmwInstallerType.WLS, "12.2.1.4.0", "x", "x");
         assertTrue(recommendedPatches.isEmpty());
     }
 

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/aru/AruUtilTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/aru/AruUtilTest.java
@@ -104,7 +104,7 @@ class AruUtilTest {
 
         // if no recommended patches are found, method should return an empty list (test data does not have 12.2.1.4)
         recommendedPatches =
-            AruUtil.rest().getRecommendedPatches(FmwInstallerType.WLS, "12.2.1.4.0", "x", "x");
+            AruUtil.rest().getRecommendedPatches(FmwInstallerType.WLSDEV, "12.2.1.4.0", "x", "x");
         assertTrue(recommendedPatches.isEmpty());
     }
 

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/installer/InstallerTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/installer/InstallerTest.java
@@ -32,10 +32,10 @@ public class InstallerTest {
     void fmwInstallerProductIds() {
         assertEquals(Arrays.asList(AruProduct.WLS, AruProduct.COH), FmwInstallerType.WLS.products(),
             "WLS product list is incorrect or out of order");
-        assertEquals(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.JDEV),
+        assertEquals(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.JRF, AruProduct.FMWPLAT, AruProduct.JDEV),
             FmwInstallerType.FMW.products(), "FMW product list is incorrect or out of order");
-        assertEquals(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.JDEV, AruProduct.SOA),
-            FmwInstallerType.SOA.products(), "SOA product list is incorrect or out of order");
+        assertEquals(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.JRF, AruProduct.FMWPLAT, AruProduct.JDEV,
+            AruProduct.SOA), FmwInstallerType.SOA.products(), "SOA product list is incorrect or out of order");
     }
 
     @Test

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/installer/InstallerTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/installer/InstallerTest.java
@@ -32,9 +32,9 @@ public class InstallerTest {
     void fmwInstallerProductIds() {
         assertEquals(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT), FmwInstallerType.WLS.products(),
             "WLS product list is incorrect or out of order");
-        assertEquals(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.JRF, AruProduct.FMWPLAT, AruProduct.JDEV),
+        assertEquals(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT, AruProduct.JRF, AruProduct.JDEV),
             FmwInstallerType.FMW.products(), "FMW product list is incorrect or out of order");
-        assertEquals(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.JRF, AruProduct.FMWPLAT, AruProduct.JDEV,
+        assertEquals(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT, AruProduct.JRF, AruProduct.JDEV,
             AruProduct.SOA), FmwInstallerType.SOA.products(), "SOA product list is incorrect or out of order");
     }
 

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/installer/InstallerTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/installer/InstallerTest.java
@@ -30,7 +30,7 @@ public class InstallerTest {
 
     @Test
     void fmwInstallerProductIds() {
-        assertEquals(Arrays.asList(AruProduct.WLS, AruProduct.COH), FmwInstallerType.WLS.products(),
+        assertEquals(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT), FmwInstallerType.WLS.products(),
             "WLS product list is incorrect or out of order");
         assertEquals(Arrays.asList(AruProduct.WLS, AruProduct.COH, AruProduct.JRF, AruProduct.FMWPLAT, AruProduct.JDEV),
             FmwInstallerType.FMW.products(), "FMW product list is incorrect or out of order");

--- a/imagetool/src/test/resources/releases.xml
+++ b/imagetool/src/test/resources/releases.xml
@@ -77,4 +77,6 @@
     <release id="606" name="12.1.0.1.0"><![CDATA[OSB 12.1.0.1.0]]></release>
     <release id="701" name="12.2.1.4.0"><![CDATA[Oracle Coherence 12.2.1.4.0]]></release>
     <release id="702" name="12.2.1.3.0"><![CDATA[Oracle Coherence 12.2.1.3.0]]></release>
+    <release id="801" name="12.2.1.3.0"><![CDATA[FMW Platform 12.2.1.3.0]]></release>
+    <release id="802" name="12.2.1.4.0"><![CDATA[FMW Platform 12.2.1.4.0]]></release>
 </results>


### PR DESCRIPTION
Added FMW Platform and Java Require Files ARU product IDs for FMW patching.  Recommended patches from Java Required Files and FMW Platform should be included when patching FMW products (except WebLogic Server stand-alone).  Images created with Image Tool prior to this change may not have the recommended FMW Platform and Java Required Files patches from the April 2021 quarterly update.