### PR TITLE
build will skip integration tests by default 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
                 withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'otn-cred', passwordVariable: 'ORACLE_SUPPORT_PASSWORD', usernameVariable: 'ORACLE_SUPPORT_USERNAME']]) {
                     sh '''
                         cd tests
-                        mvn clean verify -Dtest.staging.dir=${STAGING_DIR} -Dtest.groups=gate
+                        mvn clean verify -Dtest.staging.dir=${STAGING_DIR} -Dtest.groups=gate -DskipITs=false
                     '''
                 }
             }
@@ -84,7 +84,7 @@ pipeline {
                 withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'otn-cred', passwordVariable: 'ORACLE_SUPPORT_PASSWORD', usernameVariable: 'ORACLE_SUPPORT_USERNAME']]) {
                     sh '''
                         cd tests
-                        mvn clean verify -Dtest.staging.dir=${STAGING_DIR} -Dtest.groups=gate,nightly
+                        mvn clean verify -Dtest.staging.dir=${STAGING_DIR} -Dtest.groups=gate,nightly -DskipITs=false
                     '''
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <test.groups>gate</test.groups>
         <aggregate.report.dir>tests/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
+        <skipITs>true</skipITs>
     </properties>
 
     <modules>
@@ -91,6 +92,38 @@
     </dependencyManagement>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-build-environment</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skipITs}</skip>
+                            <rules>
+                                <requireEnvironmentVariable>
+                                    <variableName>ORACLE_SUPPORT_USERNAME</variableName>
+                                    <message>For integration tests, you must set the environment variable ORACLE_SUPPORT_USERNAME to a valid OTN credential for patch access.</message>
+                                </requireEnvironmentVariable>
+                                <requireEnvironmentVariable>
+                                    <variableName>ORACLE_SUPPORT_PASSWORD</variableName>
+                                    <message>For integration tests, you must set the environment variable ORACLE_SUPPORT_PASSWORD to match the ORACLE_SUPPORT_USERNAME credential.</message>
+                                </requireEnvironmentVariable>
+                                <requireProperty>
+                                    <property>test.staging.dir</property>
+                                    <message>For integration tests, you must define the test.staging.dir System property to point to the directory where the installers are staged. Or, set STAGING_DIR environment variable.</message>
+                                </requireProperty>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -18,7 +18,6 @@
 
     <properties>
         <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
-        <skipITs>false</skipITs>
     </properties>
 
     <dependencies>
@@ -36,36 +35,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>enforce-build-environment</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <skip>${skipITs}</skip>
-                            <rules>
-                                <requireEnvironmentVariable>
-                                    <variableName>ORACLE_SUPPORT_USERNAME</variableName>
-                                    <message>For integration tests, you must set the environment variable ORACLE_SUPPORT_USERNAME to a valid OTN credential for patch access.</message>
-                                </requireEnvironmentVariable>
-                                <requireEnvironmentVariable>
-                                    <variableName>ORACLE_SUPPORT_PASSWORD</variableName>
-                                    <message>For integration tests, you must set the environment variable ORACLE_SUPPORT_PASSWORD to match the ORACLE_SUPPORT_USERNAME credential.</message>
-                                </requireEnvironmentVariable>
-                                <requireProperty>
-                                    <property>test.staging.dir</property>
-                                    <message>For integration tests, you must define the test.staging.dir System property to point to the directory where the installers are staged. Or, set STAGING_DIR environment variable.</message>
-                                </requireProperty>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin> <!-- tests module does not have a JAR (shippable source) -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/tests/src/test/java/com/oracle/weblogic/imagetool/tests/ITImagetool.java
+++ b/tests/src/test/java/com/oracle/weblogic/imagetool/tests/ITImagetool.java
@@ -26,6 +26,7 @@ import com.oracle.weblogic.imagetool.tests.utils.CreateCommand;
 import com.oracle.weblogic.imagetool.tests.utils.RebaseCommand;
 import com.oracle.weblogic.imagetool.tests.utils.Runner;
 import com.oracle.weblogic.imagetool.tests.utils.UpdateCommand;
+import com.oracle.weblogic.imagetool.util.Utils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -49,12 +50,12 @@ class ITImagetool {
     private static final LoggingFacade logger = LoggingFactory.getLogger(ITImagetool.class);
 
     // STAGING_DIR - directory where JDK and other installers are pre-staged before testing
-    private static final String STAGING_DIR = getEnvironmentProperty("STAGING_DIR");
-    private static final String wlsImgBldDir = getEnvironmentProperty("WLSIMG_BLDDIR");
-    private static final String wlsImgCacheDir = getEnvironmentProperty("WLSIMG_CACHEDIR");
+    private static final String STAGING_DIR = System.getProperty("STAGING_DIR");
+    private static final String wlsImgBldDir = System.getProperty("WLSIMG_BLDDIR");
+    private static final String wlsImgCacheDir = System.getProperty("WLSIMG_CACHEDIR");
 
     // Docker images
-    private static final String DB_IMAGE = getEnvironmentProperty("DB_IMAGE");
+    private static final String DB_IMAGE = System.getProperty("DB_IMAGE");
 
     // Staging Dir files
     private static final String JDK_INSTALLER = "jdk-8u202-linux-x64.tar.gz";
@@ -85,46 +86,29 @@ class ITImagetool {
     private static boolean wlsImgBuilt = false;
     private static boolean domainImgBuilt = false;
 
-    /**
-     * Get the named property from system environment or Java system property.
-     * If the property is defined in the Environment, that value will take precedence over
-     * Java properties.
-     *
-     * @param name the name of the environment variable, or Java property
-     * @return the value defined in the env or system property
-     */
-    private static String getEnvironmentProperty(String name) {
-        String result = System.getenv(name);
-        if (result == null || result.isEmpty()) {
-            logger.info("Environment variable {0} not set, using Java system property", name);
-            result = System.getProperty(name);
-        }
-        return result;
-    }
-
     private static void validateEnvironmentSettings() {
         logger.info("Initializing the tests ...");
 
         List<String> missingSettings = new ArrayList<>();
-        if (wlsImgBldDir == null || wlsImgBldDir.isEmpty()) {
+        if (Utils.isEmptyString(wlsImgBldDir)) {
             missingSettings.add("WLSIMG_BLDDIR");
         }
 
-        if (wlsImgCacheDir == null || wlsImgCacheDir.isEmpty()) {
+        if (Utils.isEmptyString(wlsImgCacheDir)) {
             missingSettings.add("WLSIMG_CACHEDIR");
         }
 
-        if (STAGING_DIR == null || STAGING_DIR.isEmpty()) {
+        if (Utils.isEmptyString(STAGING_DIR)) {
             missingSettings.add("STAGING_DIR");
         }
 
-        if (DB_IMAGE == null || DB_IMAGE.isEmpty()) {
+        if (Utils.isEmptyString(DB_IMAGE)) {
             missingSettings.add("DB_IMAGE");
         }
 
         if (missingSettings.size() > 0) {
             String error = String.join(", ", missingSettings)
-                + " must be set as a system property or ENV variable";
+                + " must be set as a system property in the pom.xml";
             throw new IllegalArgumentException(error);
         }
 
@@ -285,7 +269,7 @@ class ITImagetool {
     private void buildWdtArchive() throws Exception {
         logger.info("Building WDT archive ...");
         Path scriptPath = Paths.get("src", "test", "resources", "wdt", "build-archive.sh");
-        String command = "sh " + scriptPath.toString();
+        String command = "sh " + scriptPath;
         CommandResult result = executeAndVerify(command);
         if (result.exitValue() != 0) {
             logger.severe(result.stdout());


### PR DESCRIPTION
The build will skip the integration tests by default in order to make it simpler for external customers to build the project.