### PR TITLE
Allow ImageTool home path to have spaces in directory names

### DIFF
--- a/imagetool/src/main/bin/imagetool.cmd
+++ b/imagetool/src/main/bin/imagetool.cmd
@@ -17,5 +17,5 @@ IF EXIST %JAVA_HOME%\bin\java.exe (
   ECHO Java executable does not exist at %JAVA_HOME%\bin\java.exe does not exist >&2
   EXIT /B 2
 )
-SET IMAGETOOL_HOME=%~dp0%/..
-%JAVA_HOME%\bin\java -cp %IMAGETOOL_HOME%\lib\* -Djava.util.logging.config.file=%IMAGETOOL_HOME%\bin\logging.properties com.oracle.weblogic.imagetool.cli.ImageTool %*
+SET "IMAGETOOL_HOME=%~dp0%/.."
+"%JAVA_HOME%\bin\java" -cp "%IMAGETOOL_HOME%\lib\*" "-Djava.util.logging.config.file=%IMAGETOOL_HOME%\bin\logging.properties" com.oracle.weblogic.imagetool.cli.ImageTool %*

--- a/imagetool/src/main/bin/imagetool.sh
+++ b/imagetool/src/main/bin/imagetool.sh
@@ -27,25 +27,8 @@ else
   exit -1
 fi
 
-read_link() {
-  PREV_DIR=`pwd`
-  CHASE_LINK=$1
-  cd `dirname $CHASE_LINK`
-  CHASE_LINK=`basename $CHASE_LINK`
-  while [ -L "$CHASE_LINK" ]
-  do
-    CHASE_LINK=`readlink $CHASE_LINK`
-    cd `dirname $CHASE_LINK`
-    CHASE_LINK=`basename $CHASE_LINK`
-  done
-  _DIR=`pwd -P`
-  RESULT_PATH=$_DIR/$CHASE_LINK
-  cd $PREV_DIR
-  echo $RESULT_PATH
-}
-
-script_dir=$( dirname "$( read_link "${BASH_SOURCE[0]}" )" )
+script_dir=$(dirname "${BASH_SOURCE[0]}")
 IMAGETOOL_HOME=$(cd "${script_dir}/.." ; pwd)
 export IMAGETOOL_HOME
-${JAVA_HOME}/bin/java -cp "${IMAGETOOL_HOME}/lib/*" -Djava.util.logging.config.file=${IMAGETOOL_HOME}/bin/logging.properties com.oracle.weblogic.imagetool.cli.ImageTool $@
+"${JAVA_EXE}" -cp "${IMAGETOOL_HOME}/lib/*" -Djava.util.logging.config.file="${IMAGETOOL_HOME}/bin/logging.properties" com.oracle.weblogic.imagetool.cli.ImageTool "$@"
 

--- a/imagetool/src/main/bin/setup.sh
+++ b/imagetool/src/main/bin/setup.sh
@@ -24,26 +24,9 @@ else
   return
 fi
 
-function read_link() {
-PREV_DIR=`pwd`
-CHASE_LINK=$1
-cd `dirname $CHASE_LINK`
-CHASE_LINK=`basename $CHASE_LINK`
-while [ -L "$CHASE_LINK" ]
-do
-  CHASE_LINK=`readlink $CHASE_LINK`
-  cd `dirname $CHASE_LINK`
-  CHASE_LINK=`basename $CHASE_LINK`
-done
-_DIR=`pwd -P`
-RESULT_PATH=$_DIR/$CHASE_LINK
-cd $PREV_DIR
-echo $RESULT_PATH
-}
-
 unalias imagetool 2> /dev/null
-script_dir=$( dirname "$( read_link "${BASH_SOURCE[0]}" )" )
-IMAGETOOL_HOME=`cd "${script_dir}/.." ; pwd`
+script_dir=$(dirname "${BASH_SOURCE[0]}")
+IMAGETOOL_HOME=$(cd "${script_dir}/.." ; pwd)
 export IMAGETOOL_HOME
-alias imagetool="${JAVA_HOME}/bin/java -cp \"${IMAGETOOL_HOME}/lib/*\" -Djava.util.logging.config.file=${IMAGETOOL_HOME}/bin/logging.properties com.oracle.weblogic.imagetool.cli.ImageTool"
-source ${IMAGETOOL_HOME}/lib/imagetool_completion.sh
+alias imagetool="\"${JAVA_EXE}\" -cp \"${IMAGETOOL_HOME}/lib/*\" -Djava.util.logging.config.file=\"${IMAGETOOL_HOME}/bin/logging.properties\" com.oracle.weblogic.imagetool.cli.ImageTool"
+source "${IMAGETOOL_HOME}"/lib/imagetool_completion.sh


### PR DESCRIPTION
Allow ImageTool home path to have spaces in directory names and removed symbolic link removal from the shell script.