### PR TITLE
Allow non-patching operations on images with unidentified products

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruUtil.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruUtil.java
@@ -105,7 +105,9 @@ public class AruUtil {
             logger.exiting();
             return Collections.emptyList();
         } catch (IOException | XPathExpressionException e) {
-            throw new AruException(Utils.getMessage("IMG-0032", product.description(), version), e);
+            AruException aruE = new AruException(Utils.getMessage("IMG-0032", product.description(), version), e);
+            logger.throwing(aruE);
+            throw aruE;
         }
     }
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -143,9 +143,17 @@ public class UpdateImage extends CommonOptions implements Callable<CommandRespon
 
             FmwInstallerType installerType = FmwInstallerType.fromProductList(
                 baseImageProperties.getProperty("oracleInstalledProducts"));
-            logger.info("IMG-0094", installerType);
-            // resolve required patches
-            handlePatchFiles(installerType, installedPatches);
+            if (installerType == null) {
+                logger.fine("Unable to detect installed products from image {0}", fromImage);
+                // This error occurred with the 12.2.1.4 quick slim image because registry.xml was missing data
+                if (applyingPatches()) {
+                    return new CommandResponse(1, "IMG-0096", fromImage);
+                }
+            } else {
+                logger.info("IMG-0094", installerType);
+                // resolve required patches
+                handlePatchFiles(installerType, installedPatches);
+            }
 
             // create dockerfile
             String dockerfile = Utils.writeDockerfile(tmpDir + File.separator + "Dockerfile",

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
@@ -131,6 +131,10 @@ public enum FmwInstallerType {
      */
     public static FmwInstallerType fromProductList(String products) {
         logger.entering(products);
+        if (Utils.isEmptyString(products)) {
+            return null;
+        }
+
         // create a set from the comma-separated list
         Set<AruProduct> productSet = Stream.of(products.split(","))
             .filter(e -> !"TOPLINK".equals(e)) // skip TOPLINK product (WLS always contains TOPLINK)

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -94,3 +94,4 @@ IMG-0092=ORACLE_HOME already exists in {0} (--fromImage), skipping middleware in
 IMG-0093=Patching skipped.  Using CREATE to patch --fromImage with an existing ORACLE_HOME is not supported. To create a patched image, use CREATE with a linux base image and apply the WebLogic install and patches at the same time.
 IMG-0094=Source image installer type: ([[green: {0}]])
 IMG-0095=Unable to parse response for Oracle patches in fromImage: {0}
+IMG-0096=Unable to patch image {0}. The installed products could not be identified for patching. Contact the maintainer of this image and let them know that the registry.xml may be invalid.

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -94,4 +94,4 @@ IMG-0092=ORACLE_HOME already exists in {0} (--fromImage), skipping middleware in
 IMG-0093=Patching skipped.  Using CREATE to patch --fromImage with an existing ORACLE_HOME is not supported. To create a patched image, use CREATE with a linux base image and apply the WebLogic install and patches at the same time.
 IMG-0094=Source image installer type: ([[green: {0}]])
 IMG-0095=Unable to parse response for Oracle patches in fromImage: {0}
-IMG-0096=Unable to patch image {0}. The installed products could not be identified for patching. Contact the maintainer of this image and let them know that the registry.xml may be invalid.
+IMG-0096=Unable to patch image {0}. The installed products could not be identified for patching. The most likely cause is that the registry.xml in this image may be invalid.

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/installer/InstallerTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/installer/InstallerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @Tag("unit")
 public class InstallerTest {
@@ -58,6 +59,8 @@ public class InstallerTest {
         assertEquals(FmwInstallerType.WLS, FmwInstallerType.fromProductList("WLS,COH,TOPLINK"));
         assertEquals(FmwInstallerType.FMW, FmwInstallerType.fromProductList("INFRA,WLS,COH,TOPLINK"));
         assertEquals(FmwInstallerType.SOA_OSB, FmwInstallerType.fromProductList("INFRA,WLS,COH,TOPLINK,BPM,SOA,OSB"));
+        assertNull(FmwInstallerType.fromProductList(""));
+        assertNull(FmwInstallerType.fromProductList(null));
     }
 }
 


### PR DESCRIPTION
Allow non-patching operations on images where the installed products cannot be identified through the registry.xml.  Currently, WLS 12.2.1.4-slim installer is failing to add product-family information to the registry.xml.  This missing data prevents Image Tool from identifying the installed products.

This change allows non-patching operations (like WDT commands) to continue when this situation occurs.  If the user tries to patch, Image Tool will exit with an error that gives a better description of the problem.