### PR TITLE
Fix regression with UPDATE where WDT install could not be overwritten

### DIFF
--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -33,11 +33,13 @@ ENV ORACLE_HOME={{{oracle_home}}} \
 {{/installJava}}
 {{#isWdtEnabled}}
     DOMAIN_HOME={{{domain_home}}} \
+    WDT_HOME={{{wdt_home}}} \
     {{#modelOnly}}
         WDT_MODEL_HOME={{{wdt_model_home}}} \
     {{/modelOnly}}
     {{/isWdtEnabled}}
-    PATH=${PATH}:{{{java_home}}}/bin:{{{oracle_home}}}/oracle_common/common/bin:{{{oracle_home}}}/wlserver/common/bin:{{{oracle_home}}}{{#isWdtEnabled}}:{{{domain_home}}}/bin{{/isWdtEnabled}}
+    PATH=${PATH}:{{{java_home}}}/bin:{{{oracle_home}}}/oracle_common/common/bin:{{{oracle_home}}}/wlserver/common/bin:{{{oracle_home}}}{{#isWdtEnabled}}:{{{domain_home}}}/bin
+{{/isWdtEnabled}}
 
 LABEL com.oracle.weblogic.imagetool.buildid="{{buildId}}"
 

--- a/imagetool/src/main/resources/docker-files/Update_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Update_Image.mustache
@@ -12,7 +12,8 @@ USER root
 ENV OPATCH_NO_FUSER=true
 
 {{#isWdtEnabled}}
-ENV  DOMAIN_HOME={{{domain_home}}} \
+ENV DOMAIN_HOME={{{domain_home}}} \
+    WDT_HOME={{{wdt_home}}} \
     {{#modelOnly}}
         WDT_MODEL_HOME={{{wdt_model_home}}} \
     {{/modelOnly}}

--- a/imagetool/src/main/resources/docker-files/run-wdt.mustache
+++ b/imagetool/src/main/resources/docker-files/run-wdt.mustache
@@ -36,11 +36,12 @@ RUN cd {{{wdt_home}}} \
     {{{.}}}
 {{/beforeWdtCommand}}
 
+RUN test -d {{{wdt_home}}}/weblogic-deploy && rm -rf {{{wdt_home}}}/weblogic-deploy || echo Initial WDT install \
 {{#usingWdtTarGzInstaller}}
-    RUN tar zxf {{{tempDir}}}/{{{wdtInstaller}}} -C {{{wdt_home}}}
+  && tar zxf {{{tempDir}}}/{{{wdtInstaller}}} -C {{{wdt_home}}}
 {{/usingWdtTarGzInstaller}}
 {{^usingWdtTarGzInstaller}}
-    RUN unzip -q {{{tempDir}}}/{{{wdtInstaller}}} -d {{{wdt_home}}}
+  && unzip -q {{{tempDir}}}/{{{wdtInstaller}}} -d {{{wdt_home}}}
 {{/usingWdtTarGzInstaller}}
 
 {{^modelOnly}}

--- a/imagetool/src/main/resources/probe-env/inspect-image-long.sh
+++ b/imagetool/src/main/resources/probe-env/inspect-image-long.sh
@@ -37,6 +37,13 @@ if [ -n "$WDT_MODEL_HOME" ]; then
   echo wdtModelHome="$WDT_MODEL_HOME"
 fi
 
+if [ -n "$WDT_HOME" ]; then
+  echo wdtHome="$WDT_HOME"
+  echo wdtVersion="$(cat $WDT_HOME/weblogic-deploy/VERSION.txt | sed 's/.* //')"
+elif [ -f "/u01/wdt/weblogic-deploy/VERSION.txt" ]; then
+  echo wdtHome="/u01/wdt"
+  echo wdtVersion="$(cat /u01/wdt/weblogic-deploy/VERSION.txt | sed 's/.* //')"
+fi
 
 if [ -n "$ORACLE_HOME" ]; then
   echo oracleHome="$ORACLE_HOME"

--- a/imagetool/src/main/resources/probe-env/inspect-image.sh
+++ b/imagetool/src/main/resources/probe-env/inspect-image.sh
@@ -37,6 +37,13 @@ if [ -n "$WDT_MODEL_HOME" ]; then
   echo wdtModelHome="$WDT_MODEL_HOME"
 fi
 
+if [ -n "$WDT_HOME" ]; then
+  echo wdtHome="$WDT_HOME"
+  echo wdtVersion="$(cat $WDT_HOME/weblogic-deploy/VERSION.txt | sed 's/.* //')"
+elif [ -f "/u01/wdt/weblogic-deploy/VERSION.txt" ]; then
+  echo wdtHome="/u01/wdt"
+  echo wdtVersion="$(cat /u01/wdt/weblogic-deploy/VERSION.txt | sed 's/.* //')"
+fi
 
 if [ -n "$ORACLE_HOME" ]; then
   echo oracleHome="$ORACLE_HOME"

--- a/tests/src/test/java/com/oracle/weblogic/imagetool/tests/ITImagetool.java
+++ b/tests/src/test/java/com/oracle/weblogic/imagetool/tests/ITImagetool.java
@@ -264,6 +264,28 @@ class ITImagetool {
 
     }
 
+    private static CommandResult executeAndVerify(String command) throws Exception {
+        logger.info("Executing command: " + command);
+        CommandResult result = Runner.run(command);
+        assertEquals(0, result.exitValue(), "for command: " + command);
+        logger.info(result.stdout());
+        return result;
+    }
+
+    /**
+     * Determine if a Docker image exists on the local system.
+    */
+    private static boolean imageExists(String imageTag) throws IOException, InterruptedException {
+        return !getImageId(imageTag).isEmpty();
+    }
+
+    /**
+     * Get the docker identifier for this image tag.
+     */
+    private static String getImageId(String imageTag) throws IOException, InterruptedException {
+        return Runner.run("docker images -q " + imageTag).stdout().trim();
+    }
+
     private void verifyFileInImage(String imagename, String filename, String expectedContent) throws Exception {
         logger.info("verifying the file content in image");
         String command = "docker run --rm " + imagename + " bash -c 'cat " + filename + "'";
@@ -287,14 +309,6 @@ class ITImagetool {
         // wait for the db is ready
         command = "docker ps | grep " + dbContainerName;
         checkCmdInLoop(command);
-    }
-
-    private static CommandResult executeAndVerify(String command) throws Exception {
-        logger.info("Executing command: " + command);
-        CommandResult result = Runner.run(command);
-        assertEquals(0, result.exitValue(), "for command: " + command);
-        logger.info(result.stdout());
-        return result;
     }
 
     /**
@@ -538,8 +552,8 @@ class ITImagetool {
             assertEquals(0, result.exitValue(), "for command: " + command);
 
             // verify the docker image is created
-            String imageId = Runner.run("docker images -q " + tagName, out, logger).stdout().trim();
-            assertFalse(imageId.isEmpty(), "Image was not created: " + tagName);
+            assertTrue(imageExists(tagName), "Image was not created: " + tagName);
+
             wlsImgBuilt = true;
         }
     }
@@ -568,8 +582,8 @@ class ITImagetool {
             assertEquals(0, result.exitValue(), "for command: " + command);
 
             // verify the docker image is created
-            String imageId = Runner.run("docker images -q " + tagName, out, logger).stdout().trim();
-            assertFalse(imageId.isEmpty(), "Image was not created: " + tagName);
+            assertTrue(imageExists(tagName), "Image was not created: " + tagName);
+
             // TODO should check that patch and OPatch were applied
         }
     }
@@ -603,8 +617,8 @@ class ITImagetool {
             assertEquals(0, result.exitValue(), "for command: " + command);
 
             // verify the docker image is created
-            String imageId = Runner.run("docker images -q " + tagName, out, logger).stdout().trim();
-            assertFalse(imageId.isEmpty(), "Image was not created: " + tagName);
+            assertTrue(imageExists(tagName), "Image was not created: " + tagName);
+
             domainImgBuilt = true;
         }
     }
@@ -633,8 +647,7 @@ class ITImagetool {
             assertEquals(0, result.exitValue(), "for command: " + command);
 
             // verify the docker image is created
-            String imageId = Runner.run("docker images -q " + tagName, out, logger).stdout().trim();
-            assertFalse(imageId.isEmpty(), "Image was not created: " + tagName);
+            assertTrue(imageExists(tagName), "Image was not created: " + tagName);
         }
     }
 
@@ -688,8 +701,7 @@ class ITImagetool {
             assertEquals(0, result.exitValue(), "for command: " + command);
 
             // verify the docker image is created
-            String imageId = Runner.run("docker images -q " + tagName, out, logger).stdout().trim();
-            assertFalse(imageId.isEmpty(), "Image was not created: " + tagName);
+            assertTrue(imageExists(tagName), "Image was not created: " + tagName);
         }
     }
 
@@ -744,8 +756,7 @@ class ITImagetool {
             assertEquals(0, result.exitValue(), "for command: " + command);
 
             // verify the docker image is created
-            String imageId = Runner.run("docker images -q " + tagName, out, logger).stdout().trim();
-            assertFalse(imageId.isEmpty(), "Image was not created: " + tagName);
+            assertTrue(imageExists(tagName), "Image was not created: " + tagName);
         }
     }
 
@@ -784,8 +795,7 @@ class ITImagetool {
             assertEquals(0, result.exitValue(), "for command: " + command);
 
             // verify the docker image is created
-            String imageId = Runner.run("docker images -q " + tagName, out, logger).stdout().trim();
-            assertFalse(imageId.isEmpty(), "Image was not created: " + tagName);
+            assertTrue(imageExists(tagName), "Image was not created: " + tagName);
         }
     }
 
@@ -821,8 +831,7 @@ class ITImagetool {
             assertEquals(0, result.exitValue(), "for command: " + command);
 
             // verify the docker image is created
-            String imageId = Runner.run("docker images -q " + tagName, out, logger).stdout().trim();
-            assertFalse(imageId.isEmpty(), "Image was not created: " + tagName);
+            assertTrue(imageExists(tagName), "Image was not created: " + tagName);
         }
     }
 
@@ -851,8 +860,7 @@ class ITImagetool {
             assertEquals(0, result.exitValue(), "for command: " + command);
 
             // verify the docker image is created
-            String imageId = Runner.run("docker images -q " + tagName, out, logger).stdout().trim();
-            assertFalse(imageId.isEmpty(), "Image was not created: " + tagName);
+            assertTrue(imageExists(tagName), "Image was not created: " + tagName);
         }
 
         // verify the file created in [before-jdk-install] section
@@ -891,8 +899,7 @@ class ITImagetool {
             assertEquals(0, result.exitValue(), "for command: " + command);
 
             // verify the docker image is created
-            String imageId = Runner.run("docker images -q " + tagName, out, logger).stdout().trim();
-            assertFalse(imageId.isEmpty(), "Image was not created: " + tagName);
+            assertTrue(imageExists(tagName), "Image was not created: " + tagName);
         }
     }
 
@@ -919,8 +926,7 @@ class ITImagetool {
             assertEquals(0, result.exitValue(), "for command: " + command);
 
             // verify the docker image is created
-            String imageId = Runner.run("docker images -q " + tagName, out, logger).stdout().trim();
-            assertFalse(imageId.isEmpty(), "Image was not created: " + tagName);
+            assertTrue(imageExists(tagName), "Image was not created: " + tagName);
         }
     }
 
@@ -962,8 +968,7 @@ class ITImagetool {
             assertEquals(0, result.exitValue(), "for command: " + command);
 
             // verify the docker image is created
-            String imageId = Runner.run("docker images -q " + tagName, out, logger).stdout().trim();
-            assertFalse(imageId.isEmpty(), "Image was not created: " + tagName);
+            assertTrue(imageExists(tagName), "Image was not created: " + tagName);
 
             validateDirectoryPermissions("/u01/domains", "drwxrwxr-x", tagName, out);
             validateDirectoryPermissions("/u01/wdt", "drwxrwxr-x", tagName, out);
@@ -990,5 +995,69 @@ class ITImagetool {
         assertEquals(2, tokens.length, "Unable to get directory permissions for " + directory);
         // When running on an SELinux host, the permissions shown by ls will end with a "."
         assertTrue(tokens[0].startsWith(expected), "Incorrect directory permissions for " + directory);
+    }
+
+    /**
+     * update a WLS image with a model.
+     *
+     * @throws Exception - if any error occurs
+     */
+    @Test
+    @Order(28)
+    @Tag("nightly")
+    @DisplayName("Use Update to add a WDT model to createWlsImg")
+    void updateAddModel(TestInfo testInfo) throws Exception {
+        assumeTrue(wlsImgBuilt);
+
+        String tagName = build_tag + ":" + getMethodName(testInfo);
+        String command = new UpdateCommand()
+            .fromImage(build_tag + ":createWlsImg") //from step 10, createWlsImg()
+            .tag(tagName)
+            .wdtVersion(WDT_VERSION)
+            .wdtModel(WDT_MODEL)
+            .wdtVariables(WDT_VARIABLES)
+            .wdtArchive(WDT_ARCHIVE)
+            .wdtModelOnly(true)
+            .build();
+
+        try (PrintWriter out = getTestMethodWriter(testInfo)) {
+            CommandResult result = Runner.run(command, out, logger);
+            assertEquals(0, result.exitValue(), "for command: " + command);
+
+            // verify the docker image is created
+            assertTrue(imageExists(tagName), "Image was not created: " + tagName);
+        }
+    }
+
+    /**
+     * update a WLS image with another model.
+     *
+     * @throws Exception - if any error occurs
+     */
+    @Test
+    @Order(29)
+    @Tag("nightly")
+    @DisplayName("Use Update to add a second WDT model to createWlsImg")
+    void updateAddSecondModel(TestInfo testInfo) throws Exception {
+        String testFromImage = build_tag + ":updateAddModel";
+        // skip this test if updateAddModel() failed to create an image
+        assumeTrue(imageExists(testFromImage));
+
+        String tagName = build_tag + ":" + getMethodName(testInfo);
+        String command = new UpdateCommand()
+            .fromImage(testFromImage)
+            .tag(tagName)
+            .wdtVersion(WDT_VERSION)
+            .wdtModel(WDT_MODEL2)
+            .wdtModelOnly(true)
+            .build();
+
+        try (PrintWriter out = getTestMethodWriter(testInfo)) {
+            CommandResult result = Runner.run(command, out, logger);
+            assertEquals(0, result.exitValue(), "for command: " + command);
+
+            // verify the docker image is created
+            assertTrue(imageExists(tagName), "Image was not created: " + tagName);
+        }
     }
 }

--- a/tests/src/test/java/com/oracle/weblogic/imagetool/tests/utils/UpdateCommand.java
+++ b/tests/src/test/java/com/oracle/weblogic/imagetool/tests/utils/UpdateCommand.java
@@ -3,11 +3,22 @@
 
 package com.oracle.weblogic.imagetool.tests.utils;
 
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 public class UpdateCommand extends ImageToolCommand {
 
     private String fromImage;
     private String tag;
     private String patches;
+
+    // WDT flags
+    private String wdtVersion;
+    private String wdtModel;
+    private String wdtArchive;
+    private String wdtVariables;
+    private boolean wdtModelOnly;
 
     public UpdateCommand() {
         super("update");
@@ -23,12 +34,33 @@ public class UpdateCommand extends ImageToolCommand {
         return this;
     }
 
-    public UpdateCommand tag(String name, String version) {
-        return tag(name + ":" + version);
-    }
-
     public UpdateCommand patches(String... values) {
         patches = String.join(",", values);
+        return this;
+    }
+
+    public UpdateCommand wdtVersion(String value) {
+        wdtVersion = value;
+        return this;
+    }
+
+    public UpdateCommand wdtModel(Path... values) {
+        wdtModel = Arrays.stream(values).map(Path::toString).collect(Collectors.joining(","));
+        return this;
+    }
+
+    public UpdateCommand wdtArchive(Path value) {
+        wdtArchive = value.toString();
+        return this;
+    }
+
+    public UpdateCommand wdtVariables(Path value) {
+        wdtVariables = value.toString();
+        return this;
+    }
+
+    public UpdateCommand wdtModelOnly(boolean value) {
+        wdtModelOnly = value;
         return this;
     }
 
@@ -40,6 +72,11 @@ public class UpdateCommand extends ImageToolCommand {
         return super.build()
             + field("--fromImage", fromImage)
             + field("--tag", tag)
-            + field("--patches", patches);
+            + field("--patches", patches)
+            + field("--wdtVersion", wdtVersion)
+            + field("--wdtModel", wdtModel)
+            + field("--wdtArchive", wdtArchive)
+            + field("--wdtVariables", wdtVariables)
+            + field("--wdtModelOnly", wdtModelOnly);
     }
 }


### PR DESCRIPTION
The `rm` command prior to the extract of the zip/tar.gz was lost in a merge for the previous release.  The WDT directory must be removed prior to extracting the new installer to ensure that all compiled python classes are removed from the previous WDT install.

Additionally, the INSPECT tool will now output the version of WDT installed.