### PR TITLE
Use JAVA_HOME for java version in INSPECT

### DIFF
--- a/imagetool/src/main/resources/probe-env/inspect-image-long.sh
+++ b/imagetool/src/main/resources/probe-env/inspect-image-long.sh
@@ -4,9 +4,6 @@
 #
 #Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
-if [ "$(type -p java)" ]; then
-  echo javaVersion="$(java -version 2>&1 | awk -F '\"' '/version/ {print $2}')"
-fi
 
 if [ "$(type -p dnf)" ]; then
   echo packageManager=DNF
@@ -24,6 +21,9 @@ fi
 
 if [ -n "$JAVA_HOME" ]; then
   echo javaHome="$JAVA_HOME"
+  echo javaVersion="$("$JAVA_HOME"/bin/java -version 2>&1 | awk -F '\"' '/version/ {print $2}')"
+else
+  echo javaVersion="$(java -version 2>&1 | awk -F '\"' '/version/ {print $2}')"
 fi
 
 if [ -n "$DOMAIN_HOME" ]; then

--- a/imagetool/src/main/resources/probe-env/inspect-image.sh
+++ b/imagetool/src/main/resources/probe-env/inspect-image.sh
@@ -4,9 +4,6 @@
 #
 #Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
-if [ "$(type -p java)" ]; then
-  echo javaVersion="$(java -version 2>&1 | awk -F '\"' '/version/ {print $2}')"
-fi
 
 if [ "$(type -p dnf)" ]; then
   echo packageManager=DNF
@@ -24,6 +21,9 @@ fi
 
 if [ -n "$JAVA_HOME" ]; then
   echo javaHome="$JAVA_HOME"
+  echo javaVersion="$("$JAVA_HOME"/bin/java -version 2>&1 | awk -F '\"' '/version/ {print $2}')"
+else
+  echo javaVersion="$(java -version 2>&1 | awk -F '\"' '/version/ {print $2}')"
 fi
 
 if [ -n "$DOMAIN_HOME" ]; then


### PR DESCRIPTION
Fixes #303.  When JAVA_HOME is set, INSPECT should use JAVA_HOME to determine the version of Java that is installed.  Otherwise, use Java from the PATH.