### PR TITLE
allow for missing patch description in lsinventory response

### DIFF
--- a/imagetool/src/main/resources/probe-env/inspect-image-long.sh
+++ b/imagetool/src/main/resources/probe-env/inspect-image-long.sh
@@ -56,7 +56,24 @@ if [ -n "$ORACLE_HOME" ]; then
   echo oracleHomeGroup="$(stat -c '%G' "$ORACLE_HOME")"
 
   echo opatchVersion="$($ORACLE_HOME/OPatch/opatch version 2> /dev/null | grep -oE -m 1 '([[:digit:]\.]+)')"
-  echo oraclePatches="$($ORACLE_HOME/OPatch/opatch lsinventory | awk '{ORS=";"} /^Unique Patch ID/ {print $4} /^Patch description/ {x = substr($0, 21);  print x} /^Patch\s*[0-9]+/ {print $2}' | sed 's/;$//')"
+  echo oraclePatches="$($ORACLE_HOME/OPatch/opatch lsinventory |
+  awk 'BEGIN { ORS=";" }
+      /^Unique Patch ID/ { print $4 }
+      /^Patch description/ {
+        x = substr($0, 21)
+        print x
+        descriptionNeeded = 0
+      }
+      /^Patch\s*[0-9]+/ {
+        if (descriptionNeeded)
+          print "None"
+        print $2
+        descriptionNeeded = 1
+      }
+      END {
+        if (descriptionNeeded)
+          print "None"
+      }' | sed 's/;$//')"
 
     echo oracleInstalledProducts="$(awk -F\" '{ORS=","} /product-family/ { print $2 }' $ORACLE_HOME/inventory/registry.xml | sed 's/,$//')"
 fi


### PR DESCRIPTION
Fixes #307. In some rare cases, a patch description may not be present for a given WLS patch.  This is probably a bug in the patch creation process, but this code change works around the missing description.