### PR TITLE
conceal http/s proxy value for logging when credential is present in the proxy

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -125,8 +125,8 @@ public abstract class CommonOptions {
             .tag(imageTag)
             .network(buildNetwork)
             .pull(buildPull)
-            .buildArg("http_proxy", httpProxyUrl, httpProxyUrl.contains("@"))
-            .buildArg("https_proxy", httpsProxyUrl, httpsProxyUrl.contains("@"))
+            .buildArg("http_proxy", httpProxyUrl, httpProxyUrl != null && httpProxyUrl.contains("@"))
+            .buildArg("https_proxy", httpsProxyUrl, httpsProxyUrl != null && httpsProxyUrl.contains("@"))
             .buildArg("no_proxy", nonProxyHosts);
 
         if (dockerPath != null && Files.isExecutable(dockerPath)) {

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -125,8 +125,8 @@ public abstract class CommonOptions {
             .tag(imageTag)
             .network(buildNetwork)
             .pull(buildPull)
-            .buildArg("http_proxy", httpProxyUrl)
-            .buildArg("https_proxy", httpsProxyUrl)
+            .buildArg("http_proxy", httpProxyUrl, httpProxyUrl.contains("@"))
+            .buildArg("https_proxy", httpsProxyUrl, httpsProxyUrl.contains("@"))
             .buildArg("no_proxy", nonProxyHosts);
 
         if (dockerPath != null && Files.isExecutable(dockerPath)) {

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
@@ -106,6 +106,9 @@ public class CreateImage extends CommonOptions implements Callable<CommandRespon
             }
         } catch (Exception ex) {
             logger.fine("**ERROR**", ex);
+            //TO-DO remove this
+            logger.info("Exception occurred: {0}", ex.getMessage());
+            ex.printStackTrace();
             return new CommandResponse(1, ex.getMessage());
         } finally {
             if (!skipcleanup) {

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
@@ -106,9 +106,6 @@ public class CreateImage extends CommonOptions implements Callable<CommandRespon
             }
         } catch (Exception ex) {
             logger.fine("**ERROR**", ex);
-            //TO-DO remove this
-            logger.info("Exception occurred: {0}", ex.getMessage());
-            ex.printStackTrace();
             return new CommandResponse(1, ex.getMessage());
         } finally {
             if (!skipcleanup) {


### PR DESCRIPTION
When the user specifies a proxy value that contains a user credential, do not log the proxy value in any way.

For example, 
``` bash
export http_proxy=http://blah:blah@proxy.mycompany.com:80
```
Should be concealed as:
[INFO   ] Starting build: docker build ... --build-arg http_proxy=********