### PR TITLE
Fix usage for invalid first argument

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/api/model/CommandResponse.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/api/model/CommandResponse.java
@@ -3,7 +3,10 @@
 
 package com.oracle.weblogic.imagetool.api.model;
 
+import com.oracle.weblogic.imagetool.logging.LoggingFacade;
 import com.oracle.weblogic.imagetool.util.Utils;
+
+import static picocli.CommandLine.ExitCode;
 
 public class CommandResponse {
 
@@ -13,7 +16,8 @@ public class CommandResponse {
 
     /**
      * For use with PicoCLI to return the response to the command line.
-     * @param status CLI status, 0 if normal.
+     *
+     * @param status  CLI status, 0 if normal.
      * @param message message to the user.
      */
     public CommandResponse(int status, String message, Object... messageParams) {
@@ -23,7 +27,30 @@ public class CommandResponse {
     }
 
     /**
+     * Create a new error response (status 1).
+     *
+     * @param message       error message
+     * @param messageParams parameters for the error message
+     * @return a new CommandResponse with status 1
+     */
+    public static CommandResponse error(String message, Object... messageParams) {
+        return new CommandResponse(ExitCode.SOFTWARE, message, messageParams);
+    }
+
+    /**
+     * Create a new success response (status 0).
+     *
+     * @param message       optional message
+     * @param messageParams parameters for the message
+     * @return a new CommandResponse with status 1
+     */
+    public static CommandResponse success(String message, Object... messageParams) {
+        return new CommandResponse(ExitCode.OK, message, messageParams);
+    }
+    
+    /**
      * Get the status code in this response.
+     *
      * @return the status
      */
     public int getStatus() {
@@ -32,10 +59,27 @@ public class CommandResponse {
 
     /**
      * Get the message in this response.
+     *
      * @return message to the user
      */
     public String getMessage() {
         return Utils.getMessage(message, messageParams);
     }
 
+    /**
+     * Log the response message with the provided logger.
+     *
+     * @param logger logger to use.
+     */
+    public void logResponse(LoggingFacade logger) {
+        if (Utils.isEmptyString(message)) {
+            return;
+        }
+
+        if (status == ExitCode.OK) {
+            logger.info(getMessage());
+        } else if (status == ExitCode.SOFTWARE) {
+            logger.severe(getMessage());
+        }
+    }
 }

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/InvalidCredentialException.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/InvalidCredentialException.java
@@ -5,8 +5,8 @@ package com.oracle.weblogic.imagetool.aru;
 
 import com.oracle.weblogic.imagetool.util.Utils;
 
-public class InvalidCredential extends AruException {
-    public InvalidCredential() {
+public class InvalidCredentialException extends AruException {
+    public InvalidCredentialException() {
         super(Utils.getMessage("IMG-0022"));
     }
 }

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/ImageTool.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/ImageTool.java
@@ -58,7 +58,7 @@ public class ImageTool {
     }
 
     /**
-     * Used for main entry point, and also entry point for unit tests.
+     * Executes the provided entryPoint .
      *
      * @param entryPoint must be an instance or class annotated with picocli.CommandLine.Command
      * @param out where to send stdout

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/ImageTool.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/ImageTool.java
@@ -48,7 +48,7 @@ public class ImageTool {
       * @param args command line arguments.
      */
     public static void main(String[] args) {
-        CommandResponse response = run(new ImageTool(),
+        CommandResponse response = run(ImageTool.class,
             new PrintWriter(System.out, true),
             new PrintWriter(System.err, true),
             args);
@@ -60,7 +60,7 @@ public class ImageTool {
     /**
      * Used for main entry point, and also entry point for unit tests.
      *
-     * @param entryPoint must be an object annotated with picocli.CommandLine.Command
+     * @param entryPoint must be an instance or class annotated with picocli.CommandLine.Command
      * @param out where to send stdout
      * @param err where to send stderr
      * @param args the command line arguments (minus the sub commands themselves)

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/ImageTool.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/ImageTool.java
@@ -4,7 +4,6 @@
 package com.oracle.weblogic.imagetool.cli;
 
 import java.io.PrintWriter;
-import java.util.concurrent.Callable;
 
 import com.oracle.weblogic.imagetool.api.model.CommandResponse;
 import com.oracle.weblogic.imagetool.cli.cache.CacheCLI;
@@ -18,6 +17,8 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.HelpCommand;
 import picocli.CommandLine.ParseResult;
+
+import static picocli.CommandLine.ExitCode;
 
 @Command(
         name = "imagetool",
@@ -38,18 +39,12 @@ import picocli.CommandLine.ParseResult;
         usageHelpWidth = 120,
         commandListHeading = "%nCommands:%n%nChoose from:%n"
 )
-public class ImageTool implements Callable<CommandResponse> {
+public class ImageTool {
 
     private static final LoggingFacade logger = LoggingFactory.getLogger(ImageTool.class);
 
-    @Override
-    public CommandResponse call() {
-        CommandLine.usage(ImageTool.class, System.out);
-        return new CommandResponse(0, "");
-    }
-
     /**
-     * Entry point for Image Tool.
+     * Entry point for Image Tool command line.
       * @param args command line arguments.
      */
     public static void main(String[] args) {
@@ -58,37 +53,42 @@ public class ImageTool implements Callable<CommandResponse> {
             new PrintWriter(System.err, true),
             args);
 
-        if (response != null) {
-            if (response.getStatus() != 0) {
-                logger.severe(response.getMessage());
-            } else if (!response.getMessage().isEmpty()) {
-                logger.info(response.getMessage());
-            }
-            System.exit(response.getStatus());
-        }
-        System.exit(1);
+        response.logResponse(logger);
+        System.exit(response.getStatus());
     }
 
     /**
-     * Used from main entry point, and also entry point for unit tests.
+     * Used for main entry point, and also entry point for unit tests.
+     *
+     * @param entryPoint must be an object annotated with picocli.CommandLine.Command
      * @param out where to send stdout
      * @param err where to send stderr
      * @param args the command line arguments (minus the sub commands themselves)
      */
-    public static CommandResponse run(Callable<CommandResponse> callable, PrintWriter out, PrintWriter err,
-                                      String... args) {
-
-        CommandLine cmd = new CommandLine(callable)
+    public static CommandResponse run(Object entryPoint, PrintWriter out, PrintWriter err, String... args) {
+        CommandLine cmd = new CommandLine(entryPoint)
             .setCaseInsensitiveEnumValuesAllowed(true)
             .setToggleBooleanFlags(false)
             .setUnmatchedArgumentsAllowed(false)
             .setColorScheme(CommandLine.Help.defaultColorScheme(CommandLine.Help.Ansi.AUTO))
+            .setParameterExceptionHandler(new ExceptionHandler())
             .setOut(out)
             .setErr(err);
 
-        cmd.execute(args);
+        int exit = cmd.execute(args);
+        CommandResponse response;
+        if (exit == ExitCode.USAGE) {
+            response = new CommandResponse(ExitCode.USAGE, null);
+        } else {
+            CommandLine commandLine = getSubcommand(cmd);
+            response = commandLine.getExecutionResult();
+            if (response == null) {
+                logger.fine("User requested usage by using help command");
+                response = CommandResponse.success(null);
+            }
+        }
         //Get the command line for the sub-command (if exists), and ignore the parents, like "imagetool cache listItems"
-        return getSubcommand(cmd).getExecutionResult();
+        return response;
     }
 
     /**
@@ -104,5 +104,24 @@ public class ImageTool implements Callable<CommandResponse> {
         }
 
         return commandLine;
+    }
+
+    static class ExceptionHandler implements CommandLine.IParameterExceptionHandler {
+
+        @Override
+        public int handleParseException(CommandLine.ParameterException ex, String[] args) {
+            CommandLine cmd = ex.getCommandLine();
+            PrintWriter writer = cmd.getErr();
+
+            writer.println(ex.getMessage());
+            CommandLine.UnmatchedArgumentException.printSuggestions(ex, writer);
+
+            CommandLine.Model.CommandSpec spec = cmd.getCommandSpec();
+            ex.getCommandLine().usage(writer, cmd.getColorScheme());
+
+            return cmd.getExitCodeExceptionMapper() != null
+                ? cmd.getExitCodeExceptionMapper().getExitCode(ex)
+                : spec.exitCodeOnInvalidInput();
+        }
     }
 }

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/AddEntry.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/AddEntry.java
@@ -28,9 +28,9 @@ public class AddEntry extends CacheOperation {
                 msg = String.format("Added entry %s=%s", key, location);
             }
             cache().addToCache(key, location);
-            return new CommandResponse(0, msg);
+            return CommandResponse.success(msg);
         }
-        return new CommandResponse(1, "IMG-0044");
+        return CommandResponse.error("IMG-0044");
     }
 
     @Option(

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/AddPatchEntry.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/AddPatchEntry.java
@@ -25,11 +25,11 @@ public class AddPatchEntry extends CacheAddOperation {
             List<String> patches = new ArrayList<>();
             patches.add(patchId);
             if (!Utils.validatePatchIds(patches, true)) {
-                return new CommandResponse(1, "Patch ID validation failed");
+                return CommandResponse.error("Patch ID validation failed");
             }
             return addToCache(patchId);
         } else {
-            return new CommandResponse(1, "IMG-0076", "--patchId");
+            return CommandResponse.error("IMG-0076", "--patchId");
         }
     }
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/CacheAddOperation.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/CacheAddOperation.java
@@ -17,23 +17,23 @@ public abstract class CacheAddOperation extends CacheOperation {
     CommandResponse addToCache(String key) throws CacheStoreException {
         // if file is invalid or does not exist, return an error
         if (filePath == null || !Files.isRegularFile(filePath)) {
-            return new CommandResponse(1, "IMG-0049", filePath);
+            return CommandResponse.error("IMG-0049", filePath);
         }
 
         // if the new value is the same as the existing cache value, do nothing
         String existingValue = cache().getValueFromCache(key);
         if (absolutePath().toString().equals(existingValue)) {
-            return new CommandResponse(0, "IMG-0075");
+            return CommandResponse.success("IMG-0075");
         }
 
         // if there is already a cache entry and the user did not ask to force it, return an error
         if (!force && existingValue != null) {
-            return new CommandResponse(1, "IMG-0048", key, existingValue);
+            return CommandResponse.error("IMG-0048", key, existingValue);
         }
 
         // input appears valid, add the entry to the cache and exit
         cache().addToCache(key, absolutePath().toString());
-        return new CommandResponse(0, "IMG-0050", key, cache().getValueFromCache(key));
+        return CommandResponse.success("IMG-0050", key, cache().getValueFromCache(key));
     }
 
     Path absolutePath() {

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/CacheCLI.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/CacheCLI.java
@@ -4,11 +4,8 @@
 package com.oracle.weblogic.imagetool.cli.cache;
 
 import java.util.List;
-import java.util.concurrent.Callable;
 
-import com.oracle.weblogic.imagetool.api.model.CommandResponse;
 import com.oracle.weblogic.imagetool.cli.HelpVersionProvider;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.HelpCommand;
 import picocli.CommandLine.Unmatched;
@@ -28,13 +25,7 @@ import picocli.CommandLine.Unmatched;
         },
         sortOptions = false
 )
-public class CacheCLI implements Callable<CommandResponse> {
-
-    @Override
-    public CommandResponse call() {
-        CommandLine.usage(this, System.out);
-        return new CommandResponse(0, "");
-    }
+public class CacheCLI {
 
     @Unmatched
     List<String> unmatchedOptions;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/DeleteEntry.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/DeleteEntry.java
@@ -21,20 +21,20 @@ public class DeleteEntry extends CacheOperation {
     public CommandResponse call() throws Exception {
         if (!Utils.isEmptyString(key)) {
             if (Constants.CACHE_DIR_KEY.equalsIgnoreCase(key)) {
-                return new CommandResponse(0, "Cannot delete key: " + key);
+                return CommandResponse.success("Cannot delete key: " + key);
             } else if (Constants.DELETE_ALL_FOR_SURE.equalsIgnoreCase(key)) {
                 cache().clearCache();
-                return new CommandResponse(0, "IMG-0046");
+                return CommandResponse.success("IMG-0046");
             } else {
                 String oldValue = cache().deleteFromCache(key);
                 if (oldValue != null) {
-                    return new CommandResponse(0, "IMG-0051", key, oldValue);
+                    return CommandResponse.success("IMG-0051", key, oldValue);
                 } else {
-                    return new CommandResponse(0, "IMG-0052", key);
+                    return CommandResponse.success("IMG-0052", key);
                 }
             }
         }
-        return new CommandResponse(1, "IMG-0045");
+        return CommandResponse.error("IMG-0045");
     }
 
     @Option(

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/ListCacheItems.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/ListCacheItems.java
@@ -25,7 +25,7 @@ public class ListCacheItems extends CacheOperation {
     public CommandResponse call() throws CacheStoreException {
         Map<String, String> resultMap = cache().getCacheItems();
         if (resultMap == null || resultMap.isEmpty()) {
-            return new CommandResponse(0, "IMG-0047");
+            return CommandResponse.success("IMG-0047");
         } else {
             System.out.println("Cache contents");
             String cacheDir = resultMap.getOrDefault(Constants.CACHE_DIR_KEY, null);
@@ -39,7 +39,7 @@ public class ListCacheItems extends CacheOperation {
                 .filter(entry -> pattern.matcher(entry.getKey()).matches())
                 .forEach(System.out::println);
 
-            return new CommandResponse(0, "");
+            return CommandResponse.success(null);
         }
     }
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -24,7 +24,7 @@ import com.oracle.weblogic.imagetool.aru.AruPatch;
 import com.oracle.weblogic.imagetool.aru.AruProduct;
 import com.oracle.weblogic.imagetool.aru.AruUtil;
 import com.oracle.weblogic.imagetool.aru.InstalledPatch;
-import com.oracle.weblogic.imagetool.aru.InvalidCredential;
+import com.oracle.weblogic.imagetool.aru.InvalidCredentialException;
 import com.oracle.weblogic.imagetool.aru.InvalidPatchNumberException;
 import com.oracle.weblogic.imagetool.aru.MultiplePatchVersionsException;
 import com.oracle.weblogic.imagetool.builder.BuildCommand;
@@ -163,7 +163,7 @@ public abstract class CommonOptions {
         tempDirectory = value;
     }
 
-    void init(String buildId) throws InvalidCredential, IOException {
+    void init(String buildId) throws InvalidCredentialException, IOException {
         logger.entering(buildId);
         logger.info(HelpVersionProvider.versionString());
         dockerfileOptions = new DockerfileOptions(buildId);
@@ -174,7 +174,7 @@ public abstract class CommonOptions {
 
         // if userid or password is provided, validate the pair of provided values
         if ((userId != null || password != null) && !AruUtil.checkCredentials(userId, password)) {
-            throw new InvalidCredential();
+            throw new InvalidCredentialException();
         }
 
         handleChown();

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CreateImage.java
@@ -51,7 +51,7 @@ public class CreateImage extends CommonOptions implements Callable<CommandRespon
             tmpDir = getTempDirectory();
 
             if (!Utils.validatePatchIds(patches, false)) {
-                return new CommandResponse(1, "Patch ID validation failed");
+                return CommandResponse.error("Patch ID validation failed");
             }
 
             copyOptionsFromImage(fromImage, tmpDir);
@@ -106,7 +106,7 @@ public class CreateImage extends CommonOptions implements Callable<CommandRespon
             }
         } catch (Exception ex) {
             logger.fine("**ERROR**", ex);
-            return new CommandResponse(1, ex.getMessage());
+            return CommandResponse.error(ex.getMessage());
         } finally {
             if (!skipcleanup) {
                 Utils.deleteFilesRecursively(tmpDir);
@@ -116,10 +116,9 @@ public class CreateImage extends CommonOptions implements Callable<CommandRespon
         Instant endTime = Instant.now();
         logger.exiting();
         if (dryRun) {
-            return new CommandResponse(0, "IMG-0054");
+            return CommandResponse.success("IMG-0054");
         } else {
-            return new CommandResponse(0, "IMG-0053",
-                Duration.between(startTime, endTime).getSeconds(), imageTag);
+            return CommandResponse.success("IMG-0053", Duration.between(startTime, endTime).getSeconds(), imageTag);
         }
     }
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/InspectImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/InspectImage.java
@@ -37,7 +37,7 @@ public class InspectImage implements Callable<CommandResponse> {
 
         System.out.println(new InspectOutput(baseImageProperties));
 
-        return CommandResponse.success("");
+        return CommandResponse.success(null);
     }
 
     @CommandLine.Option(

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/InspectImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/InspectImage.java
@@ -37,7 +37,7 @@ public class InspectImage implements Callable<CommandResponse> {
 
         System.out.println(new InspectOutput(baseImageProperties));
 
-        return new CommandResponse(0, "");
+        return CommandResponse.success("");
     }
 
     @CommandLine.Option(

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
@@ -75,7 +75,7 @@ public class RebaseImage extends CommonOptions implements Callable<CommandRespon
                 modelHome = baseImageProperties.getProperty("wdtModelHome", null);
                 modelOnly = Boolean.parseBoolean(baseImageProperties.getProperty("wdtModelOnly", null));
             } else {
-                return new CommandResponse(1, "Source Image not set");
+                return CommandResponse.error("Source Image not set");
             }
 
             if (!Utils.isEmptyString(targetImage)) {
@@ -94,15 +94,15 @@ public class RebaseImage extends CommonOptions implements Callable<CommandRespon
             }
 
             if (newJavaHome != null && !newJavaHome.equals(oldJavaHome)) {
-                return new CommandResponse(1, Utils.getMessage("IMG-0026"));
+                return CommandResponse.error(Utils.getMessage("IMG-0026"));
             }
 
             if (newOracleHome != null && !newOracleHome.equals(oldOracleHome)) {
-                return new CommandResponse(1, Utils.getMessage("IMG-0021"));
+                return CommandResponse.error(Utils.getMessage("IMG-0021"));
             }
 
             if (Utils.isEmptyString(domainHome)) {
-                return new CommandResponse(1, Utils.getMessage("IMG-0025"));
+                return CommandResponse.error(Utils.getMessage("IMG-0025"));
             }
 
             if (modelOnly) {
@@ -161,7 +161,7 @@ public class RebaseImage extends CommonOptions implements Callable<CommandRespon
             // add directory to pass the context
             runDockerCommand(dockerfile, cmdBuilder);
         } catch (Exception ex) {
-            return new CommandResponse(1, ex.getMessage());
+            return CommandResponse.error(ex.getMessage());
         } finally {
             if (!skipcleanup) {
                 Utils.deleteFilesRecursively(tmpDir);
@@ -171,9 +171,9 @@ public class RebaseImage extends CommonOptions implements Callable<CommandRespon
         Instant endTime = Instant.now();
         logger.exiting();
         if (dryRun) {
-            return new CommandResponse(0, "IMG-0054");
+            return CommandResponse.success("IMG-0054");
         } else {
-            return new CommandResponse(0, "IMG-0053",
+            return CommandResponse.success("IMG-0053",
                 Duration.between(startTime, endTime).getSeconds(), imageTag);
         }
     }

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
@@ -9,7 +9,6 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.net.URL;
@@ -26,7 +25,6 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -37,8 +35,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
@@ -558,39 +554,6 @@ public class Utils {
         }
 
         return workingDir;
-    }
-
-    /**
-     * Return the version number inside a opatch file.
-     *
-     * @param fileName full path to the opatch patch
-     * @return version number of the patch
-     */
-
-    public static String getOpatchVersionFromZip(String fileName) {
-
-        try (ZipFile zipFile = new ZipFile(fileName)) {
-
-            Enumeration<? extends ZipEntry> entries = zipFile.entries();
-
-            while (entries.hasMoreElements()) {
-                ZipEntry entry = entries.nextElement();
-                if (entry.getName().endsWith("/version.txt")) {
-                    InputStream stream = zipFile.getInputStream(entry);
-                    BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(stream));
-                    StringBuilder out = new StringBuilder();
-                    String line;
-                    while ((line = bufferedReader.readLine()) != null) {
-                        out.append(line);
-                    }
-                    return out.toString();
-                }
-            }
-        } catch (IOException ioe) {
-            logger.warning("Cannot read opatch file " + fileName);
-            logger.finer(ioe.getLocalizedMessage());
-        }
-        return null;
     }
 
     /**

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -98,3 +98,4 @@ IMG-0096=Unable to patch image {0}. The installed products could not be identifi
 IMG-0097=Inspecting {0}, this may take a few minutes if the image is not available locally.
 IMG-0098=Patch [[red: {0}]] is a Stack Patch Bundle, not a patch. Remove {0} from --patches and use [[cyan: --recommendedPatches]] instead.
 IMG-0099=Patch [[red: {0}]] is only for version {1} and may not be applicable to the target version {2}. Check Oracle Support, there may be another patch number for version {2}. Or check the OPatch output for results for this image.
+IMG-0100=Missing argument --fromImage. Update requires an image to be updated. Use --fromImage to specify the image to build on.

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/builder/BuilderTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/builder/BuilderTest.java
@@ -1,0 +1,46 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.weblogic.imagetool.builder;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("unit")
+class BuilderTest {
+    private final String buildContext = "/some/context";
+    private final String buildEngine = "docker";
+
+    private String expected(String options) {
+        return String.format("%s build --no-cache %s %s", buildEngine, options, buildContext);
+    }
+
+    @Test
+    void testSimpleCommand() {
+        BuildCommand cmd = new BuildCommand(buildEngine, buildContext);
+        cmd.tag("img:1");
+        assertEquals(expected("--tag img:1"), cmd.toString());
+    }
+
+    @Test
+    void testBuildWithOptions() {
+        BuildCommand cmd = new BuildCommand(buildEngine, buildContext)
+            .tag("img:2")
+            .pull(true)
+            .forceRm(true)
+            .network("private-net")
+            .buildArg("http_proxy", "http://blah/blah");
+        assertEquals(
+            expected("--tag img:2 --pull --force-rm --network private-net --build-arg http_proxy=http://blah/blah"),
+            cmd.toString());
+    }
+
+    @Test
+    void testBuildWithProxyPass() {
+        BuildCommand cmd = new BuildCommand(buildEngine, buildContext);
+        cmd.tag("img:3").buildArg("http_proxy", "http://user:pass@blah/blah", true);
+        assertEquals(expected("--tag img:3 --build-arg http_proxy=********"), cmd.toString());
+    }
+}

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/builder/BuilderTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/builder/BuilderTest.java
@@ -10,23 +10,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag("unit")
 class BuilderTest {
-    private final String buildContext = "/some/context";
-    private final String buildEngine = "docker";
+    private static final String BUILD_CONTEXT = "/some/context";
+    private static final String BUILD_ENGINE = "docker";
 
     private String expected(String options) {
-        return String.format("%s build --no-cache %s %s", buildEngine, options, buildContext);
+        return String.format("%s build --no-cache %s %s", BUILD_ENGINE, options, BUILD_CONTEXT);
     }
 
     @Test
     void testSimpleCommand() {
-        BuildCommand cmd = new BuildCommand(buildEngine, buildContext);
+        BuildCommand cmd = new BuildCommand(BUILD_ENGINE, BUILD_CONTEXT);
         cmd.tag("img:1");
         assertEquals(expected("--tag img:1"), cmd.toString());
     }
 
     @Test
     void testBuildWithOptions() {
-        BuildCommand cmd = new BuildCommand(buildEngine, buildContext)
+        BuildCommand cmd = new BuildCommand(BUILD_ENGINE, BUILD_CONTEXT)
             .tag("img:2")
             .pull(true)
             .forceRm(true)
@@ -39,7 +39,7 @@ class BuilderTest {
 
     @Test
     void testBuildWithProxyPass() {
-        BuildCommand cmd = new BuildCommand(buildEngine, buildContext);
+        BuildCommand cmd = new BuildCommand(BUILD_ENGINE, BUILD_CONTEXT);
         cmd.tag("img:3").buildArg("http_proxy", "http://user:pass@blah/blah", true);
         assertEquals(expected("--tag img:3 --build-arg http_proxy=********"), cmd.toString());
     }

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/cli/ImageToolTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/cli/ImageToolTest.java
@@ -1,0 +1,64 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.weblogic.imagetool.cli;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+
+import com.oracle.weblogic.imagetool.api.model.CommandResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("unit")
+class ImageToolTest {
+
+    private ByteArrayOutputStream byteArrayOutputStream = null;
+    private PrintWriter printStream = null;
+
+    @BeforeEach
+    void setup() {
+        byteArrayOutputStream = new ByteArrayOutputStream();
+        printStream = new PrintWriter(byteArrayOutputStream);
+    }
+
+    @AfterEach
+    void teardown() {
+        if (printStream != null) {
+            printStream.close();
+        }
+    }
+
+    @Test
+    void testUsage() {
+        // No argument should give USAGE
+        CommandResponse response = ImageTool.run(new ImageTool(), printStream, printStream);
+        assertNotNull(response);
+        assertEquals(2, response.getStatus());
+        assertTrue(byteArrayOutputStream.toString().contains("Usage: imagetool [OPTIONS]"));
+    }
+
+    @Test
+    void testHelp() {
+        // HELP argument should return usage but success code
+        CommandResponse response = ImageTool.run(new ImageTool(), printStream, printStream, "help");
+        assertNotNull(response);
+        assertEquals(0, response.getStatus());
+        assertTrue(byteArrayOutputStream.toString().contains("Usage: imagetool [OPTIONS]"));
+    }
+
+    @Test
+    void testHelp2() {
+        // HELP argument should return usage but success code
+        CommandResponse response = ImageTool.run(new ImageTool(), printStream, printStream, "--help");
+        assertNotNull(response);
+        assertEquals(0, response.getStatus());
+        assertTrue(byteArrayOutputStream.toString().contains("Usage: imagetool [OPTIONS]"));
+    }
+}

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/cli/ImageToolTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/cli/ImageToolTest.java
@@ -38,7 +38,7 @@ class ImageToolTest {
     @Test
     void testUsage() {
         // No argument should give USAGE
-        CommandResponse response = ImageTool.run(new ImageTool(), printStream, printStream);
+        CommandResponse response = ImageTool.run(ImageTool.class, printStream, printStream);
         assertNotNull(response);
         assertEquals(2, response.getStatus());
         assertTrue(byteArrayOutputStream.toString().contains("Usage: imagetool [OPTIONS]"));
@@ -47,7 +47,7 @@ class ImageToolTest {
     @Test
     void testHelp() {
         // HELP argument should return usage but success code
-        CommandResponse response = ImageTool.run(new ImageTool(), printStream, printStream, "help");
+        CommandResponse response = ImageTool.run(ImageTool.class, printStream, printStream, "help");
         assertNotNull(response);
         assertEquals(0, response.getStatus());
         assertTrue(byteArrayOutputStream.toString().contains("Usage: imagetool [OPTIONS]"));
@@ -56,7 +56,7 @@ class ImageToolTest {
     @Test
     void testHelp2() {
         // HELP argument should return usage but success code
-        CommandResponse response = ImageTool.run(new ImageTool(), printStream, printStream, "--help");
+        CommandResponse response = ImageTool.run(ImageTool.class, printStream, printStream, "--help");
         assertNotNull(response);
         assertEquals(0, response.getStatus());
         assertTrue(byteArrayOutputStream.toString().contains("Usage: imagetool [OPTIONS]"));

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/cli/cache/AddPatchEntryTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/cli/cache/AddPatchEntryTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 @Tag("unit")
 class AddPatchEntryTest {
-    private static LoggingFacade commandLogger = LoggingFactory.getLogger(AddPatchEntry.class);
+    private static final LoggingFacade commandLogger = LoggingFactory.getLogger(AddPatchEntry.class);
     private static Level oldLevel;
 
     @BeforeAll

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/util/CloseableListTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/util/CloseableListTest.java
@@ -1,0 +1,53 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.weblogic.imagetool.util;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("unit")
+class CloseableListTest {
+
+    // simple object used to test the CloseableList
+    static final class MyStream implements Closeable {
+        private boolean open;
+
+        MyStream() {
+            open = true;
+        }
+
+        @Override
+        public void close() {
+            open = false;
+        }
+
+        boolean isOpen() {
+            return open;
+        }
+    }
+
+    @Test
+    void testAutoCloseObjects() {
+        // create several closable objects (like a PrintStream...)
+        MyStream[] someStreams = { new MyStream(), new MyStream()};
+        // wrap with a list, although it shouldn't matter
+        List<MyStream> originalList = new ArrayList<>(Arrays.asList(someStreams));
+        // try-with-resource should close the outer list
+        try (CloseableList<MyStream> testList = new CloseableList<>(originalList)) {
+            // ensure that the inner objects are still "open"
+            testList.forEach(x -> assertTrue(x.isOpen()));
+        }
+        // if the CloseableList class works correctly, the inner objects should all get closed when
+        // the outer list is closed.
+        originalList.forEach(x -> assertFalse(x.isOpen()));
+    }
+}


### PR DESCRIPTION
If the first argument is not one of create, cache, update, rebase, or help, the usage statement is not displayed.