### PR TITLE
By default, trim double quotes from input values provided on the CLI

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/ImageTool.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/ImageTool.java
@@ -70,6 +70,7 @@ public class ImageTool {
             .setCaseInsensitiveEnumValuesAllowed(true)
             .setToggleBooleanFlags(false)
             .setUnmatchedArgumentsAllowed(false)
+            .setTrimQuotes(true)
             .setColorScheme(CommandLine.Help.defaultColorScheme(CommandLine.Help.Ansi.AUTO))
             .setParameterExceptionHandler(new ExceptionHandler())
             .setOut(out)


### PR DESCRIPTION
When using nested variables with quotes in shell scripts, the shell will not remove double quotes like it does on the CLI.  This setting will make those two environments consistent.