### PR TITLE
Revert domain file permissions to umask 027 with explicit OpenShift override

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -54,6 +54,10 @@ public abstract class CommonOptions {
     abstract String getInstallerVersion();
 
     private void handleChown() {
+        if (osUserAndGroup == null) {
+            return;
+        }
+
         if (osUserAndGroup.length != 2) {
             throw new IllegalArgumentException(Utils.getMessage("IMG-0027"));
         }
@@ -182,7 +186,10 @@ public abstract class CommonOptions {
 
         if (kubernetesTarget == KubernetesTarget.OpenShift) {
             dockerfileOptions.setDomainGroupAsUser(true);
-            //TODO: if not set by user, change OS group to root for dockerfileOptions
+            // if the user did not set the OS user:group, make the default oracle:root, instead of oracle:oracle
+            if (osUserAndGroup == null) {
+                dockerfileOptions.setGroupId("root");
+            }
         }
 
         logger.exiting();
@@ -502,8 +509,7 @@ public abstract class CommonOptions {
     @Option(
         names = {"--chown"},
         split = ":",
-        description = "userid:groupid for JDK/Middleware installs and patches. Default: ${DEFAULT-VALUE}.",
-        defaultValue = "oracle:oracle"
+        description = "userid:groupid for JDK/Middleware installs and patches. Default: oracle:oracle."
     )
     private String[] osUserAndGroup;
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -180,6 +180,11 @@ public abstract class CommonOptions {
         handleChown();
         handleAdditionalBuildCommands();
 
+        if (kubernetesTarget == KubernetesTarget.OpenShift) {
+            dockerfileOptions.setDomainGroupAsUser(true);
+            //TODO: if not set by user, change OS group to root for dockerfileOptions
+        }
+
         logger.exiting();
     }
 
@@ -582,6 +587,13 @@ public abstract class CommonOptions {
         description = "Executable to process the Dockerfile. Default: ${DEFAULT-VALUE}"
     )
     String buildEngine = "docker";
+
+    @Option(
+        names = {"--target"},
+        description = "Apply settings appropriate to the target environment. Default: ${DEFAULT-VALUE}"
+            + " Supported values: ${COMPLETION-CANDIDATES}"
+    )
+    KubernetesTarget kubernetesTarget = KubernetesTarget.Default;
 
     @SuppressWarnings("unused")
     @Unmatched

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/KubernetesTarget.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/KubernetesTarget.java
@@ -1,0 +1,9 @@
+// Copyright (c) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.weblogic.imagetool.cli.menu;
+
+public enum KubernetesTarget {
+    Default,
+    OpenShift
+}

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
@@ -96,6 +96,8 @@ public class DockerfileOptions {
         invLoc = DEFAULT_INV_LOC;
         oraInvDir = DEFAULT_ORAINV_DIR;
 
+        username = "oracle";
+        groupname = "oracle";
         tempDirectory = "/tmp/imagetool";
 
         baseImageName = "ghcr.io/oracle/oraclelinux:7-slim";

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
@@ -59,6 +59,7 @@ public class DockerfileOptions {
     private PackageManagerType pkgMgr;
     private List<String> patchFilenames;
     private MiddlewareInstall mwInstallers;
+    private boolean domainGroupAsUser;
 
     // WDT values
     private String wdtHome;
@@ -88,6 +89,7 @@ public class DockerfileOptions {
         updateOpatch = false;
         skipJavaInstall = false;
         skipMiddlewareInstall = false;
+        domainGroupAsUser = false;
 
         javaHome = DEFAULT_JAVA_HOME;
         oracleHome = DEFAULT_ORACLE_HOME;
@@ -1015,5 +1017,15 @@ public class DockerfileOptions {
     public DockerfileOptions setWdtBase(String value) {
         wdtBase = value;
         return this;
+    }
+
+    public DockerfileOptions setDomainGroupAsUser(boolean value) {
+        domainGroupAsUser = value;
+        return this;
+    }
+
+    @SuppressWarnings("unused")
+    public boolean domainGroupAsUser() {
+        return domainGroupAsUser;
     }
 }

--- a/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Rebase_Image.mustache
@@ -72,7 +72,9 @@ RUN mkdir -p {{domain_home}}
     {{/isWdtModelHomeOutsideWdtHome}}
 {{/modelOnly}}
 
-RUN chmod g+w {{{domain_home}}}
+{{#domainGroupAsUser}}
+    RUN chmod g=u {{{domain_home}}}
+{{/domainGroupAsUser}}
 
 WORKDIR {{{work_dir}}}
 

--- a/imagetool/src/main/resources/docker-files/final-wdt-copy.mustache
+++ b/imagetool/src/main/resources/docker-files/final-wdt-copy.mustache
@@ -10,9 +10,13 @@
     {{#isWdtModelHomeOutsideWdtHome}}
         COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{wdt_model_home}} {{wdt_model_home}}/
     {{/isWdtModelHomeOutsideWdtHome}}
-    RUN chmod g+w {{{domain_parent}}} {{{wdt_home}}} {{{wdt_model_home}}}
+    {{#domainGroupAsUser}}
+        RUN chmod g=u {{{domain_parent}}} {{{wdt_home}}} {{{wdt_model_home}}}
+    {{/domainGroupAsUser}}
 {{/modelOnly}}
 {{^modelOnly}}
     COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{{domain_home}}} {{{domain_home}}}/
-    RUN chmod g+w {{{domain_home}}}
+    {{#domainGroupAsUser}}
+        RUN chmod g=u {{{domain_home}}}
+    {{/domainGroupAsUser}}
 {{/modelOnly}}

--- a/imagetool/src/main/resources/docker-files/run-wdt.mustache
+++ b/imagetool/src/main/resources/docker-files/run-wdt.mustache
@@ -56,13 +56,17 @@ RUN test -d {{{wdt_home}}}/weblogic-deploy && rm -rf {{{wdt_home}}}/weblogic-dep
     {{#runRcu}}
         -run_rcu \
     {{/runRcu}}
-    {{{wdtVariableFileArgument}}} {{{wdtModelFileArgument}}} {{{wdtArchiveFileArgument}}} \
-    && chmod -R g+w {{{domain_home}}}
+    {{{wdtVariableFileArgument}}} {{{wdtModelFileArgument}}} {{{wdtArchiveFileArgument}}}
+    {{#domainGroupAsUser}}
+        RUN chmod -R g=u {{{domain_home}}}
+    {{/domainGroupAsUser}}
 {{/modelOnly}}
 {{#isWdtValidateEnabled}}
     RUN cd {{{wdt_home}}}/weblogic-deploy/bin \
     && rm ./*.cmd \
-    && chmod -R g+w {{{wdt_home}}}/weblogic-deploy/lib \
+    {{#domainGroupAsUser}}
+        && chmod -R g=u {{{wdt_home}}}/weblogic-deploy/lib \
+    {{/domainGroupAsUser}}
     && ./validateModel.sh {{^strictValidation}}-method lax{{/strictValidation}} \
     -oracle_home {{{oracle_home}}} \
     -domain_type {{domainType}} \

--- a/tests/src/test/java/com/oracle/weblogic/imagetool/tests/utils/CreateCommand.java
+++ b/tests/src/test/java/com/oracle/weblogic/imagetool/tests/utils/CreateCommand.java
@@ -7,6 +7,8 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+import com.oracle.weblogic.imagetool.cli.menu.KubernetesTarget;
+
 public class CreateCommand extends ImageToolCommand {
     private String version;
     private String type;
@@ -20,6 +22,7 @@ public class CreateCommand extends ImageToolCommand {
     private String passwordEnv;
     private String patches;
     private String additionalBuildCommands;
+    private String kubernetesTarget;
 
     // WDT flags
     private String wdtVersion;
@@ -89,9 +92,13 @@ public class CreateCommand extends ImageToolCommand {
         return this;
     }
 
-
     public CreateCommand additionalBuildCommands(Path value) {
         additionalBuildCommands = value.toString();
+        return this;
+    }
+
+    public CreateCommand target(KubernetesTarget value) {
+        kubernetesTarget = value.toString();
         return this;
     }
 
@@ -152,6 +159,7 @@ public class CreateCommand extends ImageToolCommand {
             + field("--passwordEnv", passwordEnv)
             + field("--patches", patches)
             + field("--additionalBuildCommands", additionalBuildCommands)
+            + field("--target", kubernetesTarget)
             + field("--wdtVersion", wdtVersion)
             + field("--wdtModel", wdtModel)
             + field("--wdtArchive", wdtArchive)


### PR DESCRIPTION
Created a new `--target` option that allows the user to specify the target Kubernetes environment.  The options are `Default` and `OpenShift`.  The OpenShift setting changes the domain directory files such that the group permissions for those files will be the same as the user permissions (group writable, in most cases).  Additionally, if the user does not supply the OS group and user setting with `--chown`, the default for this setting is changed from `oracle:oracle` to `oracle:root` to be inline with the expectations of an OpenShift environment.