### PR TITLE
Use system settings proxy for Apache HttpClientBuilder

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -281,7 +281,7 @@ public abstract class CommonOptions {
         names = {"--fromImage"},
         paramLabel = FROM_IMAGE_LABEL,
         description = "Docker image to use as base image.  Default: ${DEFAULT-VALUE}",
-        defaultValue = "ghcr.io/oracle/oraclelinux:8-slim"
+        defaultValue = Constants.ORACLE_LINUX
     )
     private String fromImage;
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Constants.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Constants.java
@@ -5,13 +5,14 @@ package com.oracle.weblogic.imagetool.util;
 
 public final class Constants {
 
-    public static final String ARU_REST_URL = "https://updates.oracle.com/Orion/Services";
+    public static final String ARU_UPDATES_HOST =
+        Utils.getEnvironmentProperty("WLSIMG_ARU_HOST", "updates.oracle.com");
+    public static final String ARU_REST_URL = "https://" + ARU_UPDATES_HOST + "/Orion/Services";
     public static final String REL_URL = ARU_REST_URL + "/metadata?table=aru_releases";
     public static final String RECOMMENDED_PATCHES_URL = ARU_REST_URL
         + "/search?patch_type=all&life_cycle=Recommended&product=%s&release=%s";
     public static final String ARU_LANG_URL = ARU_REST_URL + "/metadata?table=aru_languages";
     public static final String CONFLICTCHECKER_URL = ARU_REST_URL + "/conflict_checks";
-    public static final String GET_LSINVENTORY_URL = ARU_REST_URL + "/get_inventory_upi";
     public static final String CACHE_DIR_KEY = "cache.dir";
     public static final String DEFAULT_WLS_VERSION = "12.2.1.3.0";
     public static final String DEFAULT_JDK_VERSION = "8u202";
@@ -22,6 +23,7 @@ public final class Constants {
     public static final String PATCH_ID_REGEX =  "^(\\d{8})(?:[_][0-9][0-9](?:\\.[0-9]){3,8}\\.(\\d+))?";
     public static final String RIGID_PATCH_ID_REGEX =  "^(\\d{8})[_][0-9][0-9](?:\\.[0-9]){3,8}\\.(\\d+)";
     public static final String BUSYBOX = "busybox";
+    public static final String ORACLE_LINUX = "ghcr.io/oracle/oraclelinux:8-slim";
 
     private Constants() {
         //restrict access

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/HttpUtil.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/HttpUtil.java
@@ -120,10 +120,6 @@ public class HttpUtil {
 
         CookieStore cookieStore = new BasicCookieStore();
 
-        String proxyHost = System.getProperty("https.proxyHost");
-        String proxyPort  = System.getProperty("https.proxyPort");
-        HttpClient result;
-
         HttpClientBuilder builder = HttpClientBuilder.create()
             .setDefaultRequestConfig(config.build())
             .setRetryHandler(retryHandler())
@@ -137,13 +133,7 @@ public class HttpUtil {
             builder.setDefaultCredentialsProvider(credentialsProvider);
         }
 
-        if (proxyHost != null) {
-            // credentials are set in the getHttpExecutor
-            builder.setProxy(new HttpHost(proxyHost, Integer.parseInt(proxyPort)));
-        }
-
-        result = builder.build();
-
+        HttpClient result = builder.useSystemProperties().build();
         logger.exiting();
         return result;
     }
@@ -171,7 +161,7 @@ public class HttpUtil {
 
             executor
                 .auth(new HttpHost("login.oracle.com", 443), supportUserName, supportPassword)
-                .auth(new HttpHost("updates.oracle.com", 443), supportUserName, supportPassword)
+                .auth(new HttpHost(Constants.ARU_UPDATES_HOST, 443), supportUserName, supportPassword)
                 .authPreemptiveProxy(new HttpHost(proxyHost, Integer.parseInt(proxyPort)));
         }
         return executor;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
@@ -476,6 +476,7 @@ public class Utils {
                     break;
             }
         }
+        logger.finer("Discovered proxy setting ({0}): {1}", protocol, retVal);
         return retVal;
     }
 
@@ -510,12 +511,16 @@ public class Utils {
      * Java properties.
      *
      * @param name the name of the environment variable, or Java property
+     * @param defaultValue if no environment variable is defined, nor system property, return this value
      * @return the value defined in the env or system property
      */
-    public static String getEnvironmentProperty(String name) {
+    public static String getEnvironmentProperty(String name, String defaultValue) {
         String result = System.getenv(name);
         if (isEmptyString(result)) {
             result = System.getProperty(name);
+        }
+        if (isEmptyString(result)) {
+            return defaultValue;
         }
         return result;
     }
@@ -526,10 +531,7 @@ public class Utils {
      * @return working directory
      */
     public static String getBuildWorkingDir() throws IOException {
-        String workingDir = getEnvironmentProperty("WLSIMG_BLDDIR");
-        if (workingDir == null) {
-            workingDir = System.getProperty("user.home");
-        }
+        String workingDir = getEnvironmentProperty("WLSIMG_BLDDIR", System.getProperty("user.home"));
         Path path = Paths.get(workingDir);
 
         boolean pathExists = Files.exists(path, LinkOption.NOFOLLOW_LINKS);


### PR DESCRIPTION
Setting the proxy values in the Apache HTTP client builder caused an override of the default behaviors.  Because nonProxyHosts was not being set, the build ignored the java system property.  Removing the manual setting allows the default behavior to consume both http and https proxy values, as well as the nonProxyHosts value.