### PR TITLE
Add support for Alpine to Auxiliary image creation

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -33,7 +33,7 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Spec;
 import picocli.CommandLine.Unmatched;
 
-import static com.oracle.weblogic.imagetool.util.Constants.BUSYBOX;
+import static com.oracle.weblogic.imagetool.util.Constants.BUSYBOX_OS_IDS;
 
 public abstract class CommonOptions {
     private static final LoggingFacade logger = LoggingFactory.getLogger(CommonOptions.class);
@@ -205,8 +205,11 @@ public abstract class CommonOptions {
 
             // If the OS is busybox, the Dockerfile needs to know in order to use the correct security commands
             OperatingSystemProperties os = OperatingSystemProperties.getOperatingSystemProperties(baseImageProperties);
-            // If OS is BusyBox, set usingBusyBox() to true, else set to false.
-            dockerfileOptions.usingBusybox(os.name() != null && os.name().equalsIgnoreCase(BUSYBOX));
+            // If OS is a BusyBox type OS, set usingBusyBox() to true, else set to false.
+            if (os.name() != null) {
+                // if OS name is in BUSYBOX_OS_NAMES, set usingBusybox to true
+                dockerfileOptions.usingBusybox(BUSYBOX_OS_IDS.stream().anyMatch(os.id()::equalsIgnoreCase));
+            }
 
             String pkgMgrProp = baseImageProperties.getProperty("packageManager", "YUM");
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/inspect/OperatingSystemProperties.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/inspect/OperatingSystemProperties.java
@@ -33,6 +33,9 @@ public class OperatingSystemProperties {
         OperatingSystemProperties result = new OperatingSystemProperties();
         result.id = removeQuotes(imageProperties.getProperty("__OS__ID"));
         result.version = removeQuotes(imageProperties.getProperty("__OS__VERSION"));
+        if (result.version == null) {
+            result.version = removeQuotes(imageProperties.getProperty("__OS__VERSION_ID"));
+        }
         result.name = removeQuotes(imageProperties.getProperty("__OS__NAME"));
         return result;
     }

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Constants.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Constants.java
@@ -3,6 +3,10 @@
 
 package com.oracle.weblogic.imagetool.util;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 public final class Constants {
 
     public static final String ARU_UPDATES_HOST =
@@ -23,6 +27,7 @@ public final class Constants {
     public static final String PATCH_ID_REGEX =  "^(\\d{8})(?:[_][0-9][0-9](?:\\.[0-9]){3,8}\\.(\\d+))?";
     public static final String RIGID_PATCH_ID_REGEX =  "^(\\d{8})[_][0-9][0-9](?:\\.[0-9]){3,8}\\.(\\d+)";
     public static final String BUSYBOX = "busybox";
+    public static final List<String> BUSYBOX_OS_IDS = Collections.unmodifiableList(Arrays.asList("bb", "alpine"));
     public static final String ORACLE_LINUX = "ghcr.io/oracle/oraclelinux:8-slim";
 
     private Constants() {

--- a/imagetool/src/main/resources/docker-files/create-user-group.mustache
+++ b/imagetool/src/main/resources/docker-files/create-user-group.mustache
@@ -5,13 +5,13 @@
 #
 # Create user and group
 {{^usingBusybox}}
-RUN if [ -z "$(getent group {{groupid}})" ]; then groupadd {{groupid}} || exit -1 ; fi \
- && if [ -z "$(getent passwd {{userid}})" ]; then useradd -g {{groupid}} {{userid}} || exit -1; fi \
+RUN if [ -z "$(getent group {{groupid}})" ]; then groupadd {{groupid}} || exit 1 ; fi \
+ && if [ -z "$(getent passwd {{userid}})" ]; then useradd -g {{groupid}} {{userid}} || exit 1; fi \
  && mkdir -p /u01 \
  && chown {{userid}}:{{groupid}} /u01 \
  && chmod 775 /u01
 {{/usingBusybox}}
 {{#usingBusybox}}
-RUN if [ -z "$(grep ^{{groupid}}: /etc/group)" ]; then addgroup {{groupid}} || exit -1 ; fi \
- && if [ -z "$(grep ^{{userid}}: /etc/passwd)" ]; then adduser -D -G {{groupid}} {{userid}} || exit -1 ; fi
+RUN if [ -z "$(grep ^{{groupid}}: /etc/group)" ]; then addgroup {{groupid}} || exit 1 ; fi \
+ && if [ -z "$(grep ^{{userid}}: /etc/passwd)" ]; then adduser -D -G {{groupid}} {{userid}} || exit 1 ; fi
 {{/usingBusybox}}


### PR DESCRIPTION
Alpine is an extension of BusyBox.  This change adds support for Alpine to be used as a `--fromImage` for `createAuxImage`.  For example:
```shell
imagetool.sh createAuxImage --tag aux:1 --wdtModel ./simple1.yaml --fromImage alpine:latest
```