### PR TITLE
Always insert the OS group oracle if not already present

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonCreateOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonCreateOptions.java
@@ -46,7 +46,7 @@ public class CommonCreateOptions extends CommonPatchingOptions {
             install.copyFiles(cache(), buildDir());
             dockerfileOptions.setMiddlewareInstall(install);
         } else {
-            dockerfileOptions.setWdtBase(fromImage());
+            dockerfileOptions.setWdtBase("os_update");
         }
 
         // resolve required patches

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
@@ -110,7 +110,6 @@ public class DockerfileOptions {
         wdtVariableList = new ArrayList<>();
         wdtRunRcu = false;
         wdtStrictValidation = false;
-        wdtBase = "wls_build"; // By default, use output of Oracle Home install
     }
 
     /**
@@ -1038,9 +1037,17 @@ public class DockerfileOptions {
         return javaInstaller;
     }
 
+    /**
+     * Return the image/layer used during the container build for the WDT operations.
+     * @return wls_build or value provided by setWdtBase()
+     */
     @SuppressWarnings("unused")
     public String wdtBase() {
-        return wdtBase;
+        if (Utils.isEmptyString(wdtBase)) {
+            return "wls_build"; // By default, use the image layer created from the Oracle Home install
+        } else {
+            return wdtBase;
+        }
     }
 
     public DockerfileOptions setWdtBase(String value) {

--- a/imagetool/src/main/resources/docker-files/create-user-group.mustache
+++ b/imagetool/src/main/resources/docker-files/create-user-group.mustache
@@ -5,13 +5,15 @@
 #
 # Create user and group
 {{^usingBusybox}}
-RUN if [ -z "$(getent group {{groupid}})" ]; then groupadd {{groupid}} || exit 1 ; fi \
+RUN if [ -z "$(getent group oracle)" ]; then groupadd oracle || exit 1 ; fi \
+ && if [ -z "$(getent group {{groupid}})" ]; then groupadd {{groupid}} || exit 1 ; fi \
  && if [ -z "$(getent passwd {{userid}})" ]; then useradd -g {{groupid}} {{userid}} || exit 1; fi \
  && mkdir -p /u01 \
  && chown {{userid}}:{{groupid}} /u01 \
  && chmod 775 /u01
 {{/usingBusybox}}
 {{#usingBusybox}}
-RUN if [ -z "$(grep ^{{groupid}}: /etc/group)" ]; then addgroup {{groupid}} || exit 1 ; fi \
+RUN if [ -z "$(grep ^oracle: /etc/group)" ]; then addgroup oracle || exit 1 ; fi \
+ && if [ -z "$(grep ^{{groupid}}: /etc/group)" ]; then addgroup {{groupid}} || exit 1 ; fi \
  && if [ -z "$(grep ^{{userid}}: /etc/passwd)" ]; then adduser -D -G {{groupid}} {{userid}} || exit 1 ; fi
 {{/usingBusybox}}

--- a/imagetool/src/main/resources/docker-files/run-wdt.mustache
+++ b/imagetool/src/main/resources/docker-files/run-wdt.mustache
@@ -11,6 +11,8 @@ DOMAIN_HOME={{{domain_home}}}
 
 COPY --chown={{userid}}:{{groupid}} {{{wdtInstaller}}} {{{tempDir}}}/
 
+USER root
+
 RUN mkdir -p {{{wdt_home}}} \
 && chown {{userid}}:{{groupid}} {{{wdt_home}}}
 


### PR DESCRIPTION
When using `--chown oracle:root` or `--target OpenShift`, the group oracle was not defined in the OS when creating the image.  Reuse of those images required that all subsequent image extensions use `--chown oracle:root` or the image build would fail. By creating the OS group `oracle` even if it is not initially needed, subsequent extensions of that base image can be `--chown oracle:root` or omit the `--chown` to use the default `oracle:oracle`.   Additionally, any combination of `--chown` on a new extension image should work as well.