### PR TITLE
ensure OS packages are up to date when creating a new image

### DIFF
--- a/imagetool/src/main/resources/docker-files/package-managers.mustache
+++ b/imagetool/src/main/resources/docker-files/package-managers.mustache
@@ -5,17 +5,20 @@
 #
 # Ensure necessary OS packages are installed
 {{#useYum}}
-    RUN yum -y --downloaddir={{{tempDir}}} install gzip tar unzip libaio jq findutils diffutils {{#osPackages}}{{{.}}} {{/osPackages}}\
+    RUN yum -y update \
+    && yum -y --downloaddir={{{tempDir}}} install gzip tar unzip libaio jq findutils diffutils {{#osPackages}}{{{.}}} {{/osPackages}}\
     && yum -y --downloaddir={{{tempDir}}} clean all \
     && rm -rf /var/cache/yum/* \
     && rm -rf {{{tempDir}}}
 {{/useYum}}
 {{#useDnf}}
-    RUN dnf -y install gzip tar unzip libaio jq findutils diffutils {{#osPackages}}{{{.}}} {{/osPackages}}\
+    RUN dnf -y update \
+    && dnf -y install gzip tar unzip libaio jq findutils diffutils {{#osPackages}}{{{.}}} {{/osPackages}}\
     && dnf clean all
 {{/useDnf}}
 {{#useMicroDnf}}
-    RUN microdnf install gzip tar unzip libaio jq findutils diffutils shadow-utils {{#osPackages}}{{{.}}} {{/osPackages}}\
+    RUN microdnf update \
+    && microdnf install gzip tar unzip libaio jq findutils diffutils shadow-utils {{#osPackages}}{{{.}}} {{/osPackages}}\
     && microdnf clean all
 {{/useMicroDnf}}
 {{#useAptGet}}


### PR DESCRIPTION
See #337.  When creating new images, this change causes the package manager (yum, dnf, or microdnf) to run an update prior to installing WebLogic.  For the time periods where CVE's are fixed but the Oracle Linux Docker image update has not yet been released, this will help ensure that new images have the latest security fixes available from Oracle.