### PR TITLE
Added automatic patching for OPSS and OWSM into --recommendedPatches for FMW installs

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruProduct.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruProduct.java
@@ -23,7 +23,9 @@ public enum AruProduct {
     WCC("13946", "Oracle WebCenter Content"),
     WCP("15224", "Oracle WebCenter Portal"),
     WCS("20995", "Oracle WebCenter Sites"),
-    JDEV("11281", "Oracle JDeveloper")
+    JDEV("11281", "Oracle JDeveloper"),
+    OPSS("16606", "Oracle Platform Security Service"),
+    OWSM("12787", "Oracle Webservices Manager")
     //FIT("33256", "Fusion Internal Tools") No longer used after July 2020 PSU
     ;
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
@@ -32,7 +32,7 @@ public enum FmwInstallerType {
         InstallerType.WLSDEV),
 
     // Oracle WebLogic Server Infrastructure (JRF)
-    FMW(Utils.toSet(WLS.products, AruProduct.JRF, AruProduct.JDEV),
+    FMW(Utils.toSet(WLS.products, AruProduct.JRF, AruProduct.JDEV, AruProduct.OPSS, AruProduct.OWSM),
         InstallerType.FMW),
     // Oracle Service Bus
     OSB(Utils.toSet(FMW.products, AruProduct.OSB),

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/installer/InstallerTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/installer/InstallerTest.java
@@ -36,12 +36,13 @@ class InstallerTest {
         assertEquals(Utils.toSet(list1), FmwInstallerType.WLS.products(),
             "WLS product list is incorrect or out of order");
 
-        AruProduct[] list2 = {AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT, AruProduct.JRF, AruProduct.JDEV};
+        AruProduct[] list2 = {AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT, AruProduct.JRF, AruProduct.JDEV,
+            AruProduct.OPSS, AruProduct.OWSM};
         assertEquals(Utils.toSet(list2), FmwInstallerType.FMW.products(),
             "FMW product list is incorrect or out of order");
 
         AruProduct[] list3 = {AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT, AruProduct.JRF, AruProduct.JDEV,
-            AruProduct.SOA};
+            AruProduct.OPSS, AruProduct.OWSM, AruProduct.SOA};
         assertEquals(Utils.toSet(list3), FmwInstallerType.SOA.products(),
             "SOA product list is incorrect or out of order");
     }
@@ -56,11 +57,13 @@ class InstallerTest {
 
     @Test
     void fromProductList() {
-        assertEquals(FmwInstallerType.WLS, FmwInstallerType.fromProductList("WLS,COH,TOPLINK"));
-        assertEquals(FmwInstallerType.FMW, FmwInstallerType.fromProductList("INFRA,WLS,COH,TOPLINK"));
-        assertEquals(FmwInstallerType.SOA_OSB, FmwInstallerType.fromProductList("INFRA,WLS,COH,TOPLINK,BPM,SOA,OSB"));
+        final String WLS_PRODUCTS = "WLS,COH,TOPLINK";
+        final String FMW_PRODUCTS = WLS_PRODUCTS + ",INFRA,OPSS,OWSM";
+        assertEquals(FmwInstallerType.WLS, FmwInstallerType.fromProductList(WLS_PRODUCTS));
+        assertEquals(FmwInstallerType.FMW, FmwInstallerType.fromProductList(FMW_PRODUCTS));
+        assertEquals(FmwInstallerType.SOA_OSB, FmwInstallerType.fromProductList(FMW_PRODUCTS + ",BPM,SOA,OSB"));
         // Ignore unsupported products, but keep as many products as possible that ARE known
-        assertEquals(FmwInstallerType.FMW, FmwInstallerType.fromProductList("INFRA,WLS,COH,TOPLINK,OIM"));
+        assertEquals(FmwInstallerType.FMW, FmwInstallerType.fromProductList(FMW_PRODUCTS + ",OIM"));
         assertNull(FmwInstallerType.fromProductList(""));
         assertNull(FmwInstallerType.fromProductList(null));
     }


### PR DESCRIPTION
The OPSS and OWSM recommended patches for WLS were published under separate product IDs from WLS for the January 2021 CPU.  This change will include those recommendations into --recommendedPatches when using FMW installs including upper stack products like SOA, OSB, WC, etc.