### PR TITLE
Added automatic patching for the Oracle JDBC driver into --recommendedPatches for WLS/FMW installs

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruProduct.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruProduct.java
@@ -25,7 +25,8 @@ public enum AruProduct {
     WCS("20995", "Oracle WebCenter Sites"),
     JDEV("11281", "Oracle JDeveloper"),
     OPSS("16606", "Oracle Platform Security Service"),
-    OWSM("12787", "Oracle Webservices Manager")
+    OWSM("12787", "Oracle Webservices Manager"),
+    JDBC("9512", "Oracle JDBC for Fusion Middleware")
     //FIT("33256", "Fusion Internal Tools") No longer used after July 2020 PSU
     ;
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
@@ -24,7 +24,7 @@ public enum FmwInstallerType {
     // data from https://updates.oracle.com/Orion/Services/metadata?table=aru_products
 
     // Oracle WebLogic Server
-    WLS(Utils.toSet(AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT),
+    WLS(Utils.toSet(AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT, AruProduct.JDBC),
         InstallerType.WLS),
     WLSSLIM(Utils.toSet(WLS.products),
         InstallerType.WLSSLIM),

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/installer/InstallerTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/installer/InstallerTest.java
@@ -32,17 +32,17 @@ class InstallerTest {
 
     @Test
     void fmwInstallerProductIds() {
-        AruProduct[] list1 = {AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT};
+        AruProduct[] list1 = {AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT, AruProduct.JDBC};
         assertEquals(Utils.toSet(list1), FmwInstallerType.WLS.products(),
             "WLS product list is incorrect or out of order");
 
-        AruProduct[] list2 = {AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT, AruProduct.JRF, AruProduct.JDEV,
-            AruProduct.OPSS, AruProduct.OWSM};
+        AruProduct[] list2 = {AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT, AruProduct.JDBC,
+            AruProduct.JRF, AruProduct.JDEV, AruProduct.OPSS, AruProduct.OWSM};
         assertEquals(Utils.toSet(list2), FmwInstallerType.FMW.products(),
             "FMW product list is incorrect or out of order");
 
-        AruProduct[] list3 = {AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT, AruProduct.JRF, AruProduct.JDEV,
-            AruProduct.OPSS, AruProduct.OWSM, AruProduct.SOA};
+        AruProduct[] list3 = {AruProduct.WLS, AruProduct.COH, AruProduct.FMWPLAT, AruProduct.JDBC,
+            AruProduct.JRF, AruProduct.JDEV, AruProduct.OPSS, AruProduct.OWSM, AruProduct.SOA};
         assertEquals(Utils.toSet(list3), FmwInstallerType.SOA.products(),
             "SOA product list is incorrect or out of order");
     }
@@ -57,7 +57,7 @@ class InstallerTest {
 
     @Test
     void fromProductList() {
-        final String WLS_PRODUCTS = "WLS,COH,TOPLINK";
+        final String WLS_PRODUCTS = "WLS,COH,TOPLINK,JDBC";
         final String FMW_PRODUCTS = WLS_PRODUCTS + ",INFRA,OPSS,OWSM";
         assertEquals(FmwInstallerType.WLS, FmwInstallerType.fromProductList(WLS_PRODUCTS));
         assertEquals(FmwInstallerType.FMW, FmwInstallerType.fromProductList(FMW_PRODUCTS));


### PR DESCRIPTION
JDBC patch recommendations are now OPatch compatible for WLS/FMW installations.  JDBC released a recommended patch with the Oracle FMW January CPU.