### PR TITLE
Allow createAuxImage to install the WDT installer and the WDT model files separately

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/AddInstallerEntry.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/cache/AddInstallerEntry.java
@@ -19,6 +19,9 @@ public class AddInstallerEntry extends CacheAddOperation {
 
     @Override
     public CommandResponse call() throws CacheStoreException {
+        if ("NONE".equalsIgnoreCase(version)) {
+            throw new IllegalArgumentException("IMG-0105");
+        }
         String key = String.format("%s%s%s", type, CacheStore.CACHE_KEY_SEPARATOR, version);
         return addToCache(key);
     }

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/UpdateImage.java
@@ -64,7 +64,7 @@ public class UpdateImage extends CommonPatchingOptions implements Callable<Comma
             }
             dockerfileOptions.setOracleHome(oracleHome);
 
-            if (wdtOptions.isUsingWdt() && !wdtOptions.modelOnly()) {
+            if (wdtOptions.userProvidedFiles() && !wdtOptions.modelOnly()) {
                 String domainHome = baseImageProperties.getProperty("domainHome", null);
                 if (domainHome == null && wdtOperation == WdtOperation.UPDATE) {
                     return CommandResponse.error("IMG-0071", fromImage());

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
@@ -720,6 +720,11 @@ public class DockerfileOptions {
         return wdtVariableList;
     }
 
+    @SuppressWarnings("unused")
+    public boolean hasWdtFiles() {
+        return !wdtModelList.isEmpty() || !wdtVariableList.isEmpty() || !wdtArchiveList.isEmpty();
+    }
+
     /**
      * Referenced by Dockerfile template, provides the WDT argument for 1..n variable files.
      *

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
@@ -601,6 +601,10 @@ public class DockerfileOptions {
         return useWdt;
     }
 
+    public boolean installWdt() {
+        return wdtInstallerFilename != null;
+    }
+
     /**
      * Referenced by the Dockerfile template to determine which command to use to install WDT.
      *

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -100,3 +100,7 @@ IMG-0098=Patch [[red: {0}]] is a Stack Patch Bundle, not a patch. Remove {0} fro
 IMG-0099=Patch [[red: {0}]] is only for version {1} and may not be applicable to the target version {2}. Check Oracle Support, there may be another patch number for version {2}. Or check the OPatch output for results for this image.
 IMG-0100=Missing argument --fromImage. Update requires an image to be updated. Use --fromImage to specify the image to build on.
 IMG-0101=The version of OPatch that you requested is not available: {0}
+IMG-0102=WDT {0} file [[brightred: {1}]] could not be found.
+IMG-0103=wdtVersion cannot be none, a valid version from the Image Tool cache is required.
+IMG-0104=You must provide at least one of: a WDT installer file, a WDT model file, a WDT variable file, or a WDT archive file.
+IMG-0105=Installer version cannot use keyword of 'none'.

--- a/imagetool/src/main/resources/docker-files/aux-image.mustache
+++ b/imagetool/src/main/resources/docker-files/aux-image.mustache
@@ -22,15 +22,17 @@ RUN mkdir -p {{{wdt_home}}} \
  && mkdir -p {{{wdt_model_home}}} \
  && chown {{userid}}:{{groupid}} {{{wdt_home}}}
 
-COPY --chown={{userid}}:{{groupid}} {{{wdtInstaller}}} {{{tempDir}}}/
+{{#installWdt}}
+    COPY --chown={{userid}}:{{groupid}} {{{wdtInstaller}}} {{{tempDir}}}/
 
-RUN test -d {{{wdt_home}}}/weblogic-deploy && rm -rf {{{wdt_home}}}/weblogic-deploy || echo Initial WDT install \
-{{#usingWdtTarGzInstaller}}
-    && tar zxf {{{tempDir}}}/{{{wdtInstaller}}} -C {{{wdt_home}}}
-{{/usingWdtTarGzInstaller}}
-{{^usingWdtTarGzInstaller}}
-    && unzip -q {{{tempDir}}}/{{{wdtInstaller}}} -d {{{wdt_home}}}
-{{/usingWdtTarGzInstaller}}
+    RUN test -d {{{wdt_home}}}/weblogic-deploy && rm -rf {{{wdt_home}}}/weblogic-deploy || echo Initial WDT install \
+    {{#usingWdtTarGzInstaller}}
+        && tar zxf {{{tempDir}}}/{{{wdtInstaller}}} -C {{{wdt_home}}}
+    {{/usingWdtTarGzInstaller}}
+    {{^usingWdtTarGzInstaller}}
+        && unzip -q {{{tempDir}}}/{{{wdtInstaller}}} -d {{{wdt_home}}}
+    {{/usingWdtTarGzInstaller}}
+{{/installWdt}}
 
 FROM os_update as final
 
@@ -54,9 +56,7 @@ COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
     COPY --chown={{userid}}:{{groupid}} {{{.}}} {{{wdt_model_home}}}/
 {{/wdtVariables}}
 
-{{#isWdtEnabled}}
-    RUN chmod -R 640 {{{wdt_model_home}}}/*
-{{/isWdtEnabled}}
+#RUN chmod -R 640 {{{wdt_model_home}}}/*
 
 USER {{userid}}
 

--- a/imagetool/src/main/resources/docker-files/aux-image.mustache
+++ b/imagetool/src/main/resources/docker-files/aux-image.mustache
@@ -56,7 +56,9 @@ COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
     COPY --chown={{userid}}:{{groupid}} {{{.}}} {{{wdt_model_home}}}/
 {{/wdtVariables}}
 
-#RUN chmod -R 640 {{{wdt_model_home}}}/*
+{{#hasWdtFiles}}
+  RUN chmod -R 640 {{{wdt_model_home}}}/*
+{{/hasWdtFiles}}
 
 USER {{userid}}
 


### PR DESCRIPTION
This change allows `createAuxImage` to create auxiliary images without installing WDT (such as models only).  By specifying the command line option `--wdtVersion=NONE`, the WDT installer step for `createAuxImage` is skipped. 
 Model, Variable, and Archive files remain optional for `createAuxImage`.

Illegal options:
- `create` using WDT files but wdtVersion set to NONE.
- `createAuxImage` with no WDT files and wdtVersion set to NONE.

A separate PR for the documentation change is required before release.