### PR TITLE
Added additional retry logic for retrieving Oracle patches

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/RetryFailedException.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/RetryFailedException.java
@@ -1,0 +1,7 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.weblogic.imagetool.aru;
+
+public class RetryFailedException extends Exception {
+}

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -104,3 +104,8 @@ IMG-0102=WDT {0} file [[brightred: {1}]] could not be found.
 IMG-0103=wdtVersion cannot be none, a valid version from the Image Tool cache is required.
 IMG-0104=You must provide at least one of: a WDT installer file, a WDT model file, a WDT variable file, or a WDT archive file.
 IMG-0105=Installer version cannot use keyword of 'none'.
+IMG-0106=Failed to get response from patches server, {0}, retrying [{1}/{2}]
+IMG-0107=Failed to download and save file {0} from {1}: {2}
+IMG-0108=Environment variable {0}=`{1}` is not an integer and will be ignored.
+IMG-0109=Invalid value found in {0}.  {1} < {2}.  Using default value: {3}.
+IMG-0110=Retries exhausted, unable to obtain patch information from Oracle

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/aru/AruUtilTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/aru/AruUtilTest.java
@@ -77,7 +77,6 @@ class AruUtilTest {
                 e.printStackTrace();
                 throw new RuntimeException("failed to load resources XML", e);
             }
-            verifyResponse(result);
             return result;
         }
 


### PR DESCRIPTION
Retrieving WebLogic patch and release metadata has been unreliable for some users.  This change has added macro level retries around the REST calls that retrieve patch and release metadata.