### PR TITLE
Omit WDT binary copy statement in Aux image build when source directory is empty

### DIFF
--- a/imagetool/src/main/resources/docker-files/aux-image.mustache
+++ b/imagetool/src/main/resources/docker-files/aux-image.mustache
@@ -40,9 +40,14 @@ ENV AUXILIARY_IMAGE_PATH={{{wdt_home}}} \
     WDT_HOME={{{wdt_home}}} \
     WDT_MODEL_HOME={{{wdt_model_home}}}
 
-RUN mkdir -p {{{wdt_home}}} {{{wdt_model_home}}} \
- && chown {{userid}}:{{groupid}} {{{wdt_home}}} {{{wdt_model_home}}}
-COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
+{{#installWdt}}
+    RUN mkdir -p {{{wdt_home}}} && chown {{userid}}:{{groupid}} {{{wdt_home}}}
+    COPY --from=wdt_build --chown={{userid}}:{{groupid}} {{wdt_home}} {{wdt_home}}/
+{{/installWdt}}
+
+{{#hasWdtFiles}}
+    RUN mkdir -p {{{wdt_model_home}}} && chown {{userid}}:{{groupid}} {{{wdt_model_home}}}
+{{/hasWdtFiles}}
 
 {{#wdtModels}}
     COPY --chown={{userid}}:{{groupid}} {{{.}}} {{{wdt_model_home}}}/


### PR DESCRIPTION
Docker build failed for auxiliary image with option wdtVersion="NONE".  On some combinations of operating systems and Docker versions (and buildkit), the container image build fails with 
_failed to export image: failed to create image: failed to get layer sha256..._.

This change skips the COPY step when no WDT binaries were installed in the intermediate build image.

Jira -OWLS-97125