### PR TITLE
another attempt to workaround bug in coverage reporting for Sonar scanner

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,6 @@ pipeline {
         // variables for SystemTest stages (integration tests)
         STAGING_DIR = "/scratch/artifacts/imagetool"
         DB_IMAGE = "phx.ocir.io/weblogick8s/database/enterprise:12.2.0.1-slim"
-        JACOCO_REPORT_PATH = "${WORKSPACE}/imagetool/target/site/jacoco/jacoco.xml"
     }
 
     stages {
@@ -141,7 +140,6 @@ void runSonarScanner() {
     def repo = changeUrl[4].substring(0, changeUrl[4].length() - 4)
     if (env.CHANGE_ID != null) {
         sh "mvn -B sonar:sonar \
-            -Dsonar.coverage.jacoco.xmlReportPaths=${JACOCO_REPORT_PATH} \
             -Dsonar.projectKey=${org}_${repo} \
             -Dsonar.pullrequest.provider=GitHub \
             -Dsonar.pullrequest.github.repository=${org}/${repo} \
@@ -150,7 +148,6 @@ void runSonarScanner() {
             -Dsonar.pullrequest.base=${env.CHANGE_TARGET}"
     } else {
        sh "mvn -B sonar:sonar \
-            -Dsonar.coverage.jacoco.xmlReportPaths=${JACOCO_REPORT_PATH} \
            -Dsonar.projectKey=${org}_${repo} \
            -Dsonar.branch.name=${env.BRANCH_NAME}"
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
         // variables for SystemTest stages (integration tests)
         STAGING_DIR = "/scratch/artifacts/imagetool"
         DB_IMAGE = "phx.ocir.io/weblogick8s/database/enterprise:12.2.0.1-slim"
+        JACOCO_REPORT_PATH = "${WORKSPACE}/imagetool/target/site/jacoco/jacoco.xml"
     }
 
     stages {
@@ -140,6 +141,7 @@ void runSonarScanner() {
     def repo = changeUrl[4].substring(0, changeUrl[4].length() - 4)
     if (env.CHANGE_ID != null) {
         sh "mvn -B sonar:sonar \
+            -Dsonar.coverage.jacoco.xmlReportPaths=${JACOCO_REPORT_PATH} \
             -Dsonar.projectKey=${org}_${repo} \
             -Dsonar.pullrequest.provider=GitHub \
             -Dsonar.pullrequest.github.repository=${org}/${repo} \
@@ -148,6 +150,7 @@ void runSonarScanner() {
             -Dsonar.pullrequest.base=${env.CHANGE_TARGET}"
     } else {
        sh "mvn -B sonar:sonar \
+            -Dsonar.coverage.jacoco.xmlReportPaths=${JACOCO_REPORT_PATH} \
            -Dsonar.projectKey=${org}_${repo} \
            -Dsonar.branch.name=${env.BRANCH_NAME}"
     }

--- a/imagetool/pom.xml
+++ b/imagetool/pom.xml
@@ -17,10 +17,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <properties>
-        <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -75,18 +71,6 @@
         </resources>
         <plugins>
             <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
             </plugin>
@@ -118,6 +102,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruUtil.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruUtil.java
@@ -374,7 +374,7 @@ public class AruUtil {
      * @param password password
      * @return true if credentials are valid
      */
-    public static boolean checkCredentials(String username, String password) {
+    public boolean checkCredentials(String username, String password) {
         if (username == null || username.isEmpty() || password == null || password.isEmpty()) {
             return false;
         }

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/cli/menu/CommonPatchingOptionsTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/cli/menu/CommonPatchingOptionsTest.java
@@ -1,0 +1,177 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.weblogic.imagetool.cli.menu;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+
+import com.oracle.weblogic.imagetool.aru.AruException;
+import com.oracle.weblogic.imagetool.aru.AruPatch;
+import com.oracle.weblogic.imagetool.aru.AruUtil;
+import com.oracle.weblogic.imagetool.aru.InvalidCredentialException;
+import com.oracle.weblogic.imagetool.installer.FmwInstallerType;
+import com.oracle.weblogic.imagetool.logging.LoggingFacade;
+import com.oracle.weblogic.imagetool.logging.LoggingFactory;
+import com.oracle.weblogic.imagetool.util.InvalidPatchIdFormatException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("unit")
+class CommonPatchingOptionsTest {
+    private static final LoggingFacade logger = LoggingFactory.getLogger(AruUtil.class);
+    private static Level oldLevel;
+
+    @BeforeAll
+    static void setUp() {
+        oldLevel = logger.getLevel();
+        logger.setLevel(Level.SEVERE);
+    }
+
+    public static class TestAruUtil extends AruUtil {
+
+        public TestAruUtil() {
+        }
+
+        @Override
+        public boolean checkCredentials(String username, String password) {
+            return true;
+        }
+
+        @Override
+        public List<AruPatch> getRecommendedPatches(FmwInstallerType type, String version,
+                                                    String userId, String password) throws AruException {
+            List<AruPatch> list = new ArrayList<>();
+            list.add(new AruPatch().patchId("1").description("psu").psuBundle("x"));
+            list.add(new AruPatch().patchId("2").description("blah"));
+            list.add(new AruPatch().patchId("3").description("ADR FOR WEBLOGIC SERVER"));
+            return list;
+        }
+    }
+
+    @AfterAll
+    static void tearDown() {
+        logger.setLevel(oldLevel);
+    }
+
+    @Test
+    void noPassword() {
+        CreateImage createImage = new CreateImage();
+        new CommandLine(createImage).parseArgs("--tag", "tag:1", "--user", "derek");
+        assertThrows(InvalidCredentialException.class, createImage::initializeOptions);
+    }
+
+    @Test
+    void withPassword() throws Exception {
+        CreateImage createImage = new CreateImage();
+        new CommandLine(createImage).parseArgs("--tag", "tag:1", "--user", "derek", "--password", "xxx");
+
+        // insert test class into AruUtil to intercept REST calls to ARU
+        Field aruRest = AruUtil.class.getDeclaredField("instance");
+        aruRest.setAccessible(true);
+        aruRest.set(aruRest, new CommonPatchingOptionsTest.TestAruUtil());
+
+        assertFalse(createImage.applyingPatches(), "No patches on the command line, but applyingPatches is true");
+    }
+
+    @Test
+    void invalidPatchId() throws Exception {
+        CreateImage createImage = new CreateImage();
+        new CommandLine(createImage).parseArgs("--tag", "tag:1", "--user", "derek", "--password", "xxx",
+            "--patches", "abc");
+
+        // insert test class into AruUtil to intercept REST calls to ARU
+        Field aruRest = AruUtil.class.getDeclaredField("instance");
+        aruRest.setAccessible(true);
+        aruRest.set(aruRest, new CommonPatchingOptionsTest.TestAruUtil());
+
+        assertThrows(InvalidPatchIdFormatException.class, createImage::initializeOptions);
+    }
+
+    @Test
+    void invalidPatchIdTooFewDigits() throws Exception {
+        CreateImage createImage = new CreateImage();
+        new CommandLine(createImage).parseArgs("--tag", "tag:1", "--user", "derek", "--password", "xxx",
+            "--patches", "1234567");
+
+        // insert test class into AruUtil to intercept REST calls to ARU
+        Field aruRest = AruUtil.class.getDeclaredField("instance");
+        aruRest.setAccessible(true);
+        aruRest.set(aruRest, new CommonPatchingOptionsTest.TestAruUtil());
+
+        assertThrows(InvalidPatchIdFormatException.class, createImage::initializeOptions);
+    }
+
+    @Test
+    void validPatchId() throws Exception {
+        CreateImage createImage = new CreateImage();
+        new CommandLine(createImage).parseArgs("--tag", "tag:1", "--user", "derek", "--password", "xxx",
+            "--patches", "12345678");
+
+        // insert test class into AruUtil to intercept REST calls to ARU
+        Field aruRest = AruUtil.class.getDeclaredField("instance");
+        aruRest.setAccessible(true);
+        aruRest.set(aruRest, new CommonPatchingOptionsTest.TestAruUtil());
+
+        createImage.initializeOptions();
+        assertTrue(createImage.applyingPatches(), "User provided patches but applyingPatches still false");
+    }
+
+    @Test
+    void doNotGetRecommendedPatches() throws Exception {
+        CreateImage createImage = new CreateImage();
+        new CommandLine(createImage).parseArgs("--tag", "tag:1", "--user", "derek", "--password", "xxx",
+            "--patches", "12345678");
+
+        // insert test class into AruUtil to intercept REST calls to ARU
+        Field aruRest = AruUtil.class.getDeclaredField("instance");
+        aruRest.setAccessible(true);
+        aruRest.set(aruRest, new CommonPatchingOptionsTest.TestAruUtil());
+
+        List<AruPatch> patches = createImage.getRecommendedPatchList(FmwInstallerType.WLS);
+        assertTrue(patches.isEmpty(), "Neither latestPSU nor recommendedPatches was specified, but returned patches");
+    }
+
+    @Test
+    void getRecommendedPatches() throws Exception {
+        CreateImage createImage = new CreateImage();
+        new CommandLine(createImage).parseArgs("--tag", "tag:1", "--user", "derek", "--password", "xxx",
+            "--patches", "12345678", "--recommendedPatches");
+
+        // insert test class into AruUtil to intercept REST calls to ARU
+        Field aruRest = AruUtil.class.getDeclaredField("instance");
+        aruRest.setAccessible(true);
+        aruRest.set(aruRest, new CommonPatchingOptionsTest.TestAruUtil());
+
+        createImage.initializeOptions();
+        List<AruPatch> patches = createImage.getRecommendedPatchList(FmwInstallerType.WLS);
+        assertFalse(patches.isEmpty(), "recommendedPatches was specified, but returned patches was empty");
+        assertEquals(2, patches.size(),"ADR patch was not removed?");
+    }
+
+    @Test
+    void getRecommendedPatchesWithoutCredentials() throws Exception {
+        CreateImage createImage = new CreateImage();
+        new CommandLine(createImage).parseArgs("--tag", "tag:1",
+            "--patches", "12345678", "--recommendedPatches");
+
+        // insert test class into AruUtil to intercept REST calls to ARU
+        Field aruRest = AruUtil.class.getDeclaredField("instance");
+        aruRest.setAccessible(true);
+        aruRest.set(aruRest, new CommonPatchingOptionsTest.TestAruUtil());
+
+        createImage.initializeOptions();
+        assertThrows(IllegalArgumentException.class, () -> createImage.getRecommendedPatchList(FmwInstallerType.WLS));
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -33,13 +33,11 @@
     <properties>
         <sonar.organization>oracle</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.coverage.jacoco.xmlReportPaths>tests/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <test.groups>gate</test.groups>
-        <aggregate.report.dir>tests/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
         <skipITs>true</skipITs>
     </properties>
 
@@ -262,6 +260,21 @@
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.8.7</version>
+                    <executions>
+                        <execution>
+                            <id>prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>report</id>
+                            <phase>test</phase>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.sonarsource.scanner.maven</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -86,7 +86,7 @@
                 <configuration>
                     <encoding>UTF-8</encoding>
                     <failIfNoTests>false</failIfNoTests>
-                    <argLine>@{argLine} -Xmx1024m -XX:MaxPermSize=256m</argLine>
+                    <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
                     <systemPropertyVariables>
                         <WLSIMG_BLDDIR>${project.build.directory}/blddir</WLSIMG_BLDDIR>
                         <WLSIMG_CACHEDIR>${project.build.directory}/cachedir</WLSIMG_CACHEDIR>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -16,10 +16,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <properties>
-        <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
-    </properties>
-
     <dependencies>
         <dependency>
             <artifactId>imagetool</artifactId>
@@ -83,25 +79,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>prepare-agent-it</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>report</id>
-                        <goals>
-                            <goal>report-aggregate</goal>
-                        </goals>
-                        <phase>verify</phase>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Using the -D for the xmlReportPath appears to be more reliable at getting Sonar to recognize the coverage reported by Jacoco.  Recommended in reply from SonarScanner team, I dropped all references to xmlReportPath to allow the tool to default.  As long as the default directories are used, this appears to work.

This change, also, removes the test report aggregation step.  There is only one module reporting unit test coverage, and Surefire tests are not generating any reportable coverage.