### PR TITLE
Document environment variables available to additional build commands

### DIFF
--- a/documentation/1.11/content/userguide/tools/create-aux-image.md
+++ b/documentation/1.11/content/userguide/tools/create-aux-image.md
@@ -50,10 +50,10 @@ This is an advanced option that let's you provide additional commands to the Doc
 The input for this parameter is a simple text file that contains one or more of the valid sections.
 Valid sections for `createAuxImage` are:
 
-| Section | Build Stage | Timing |
-| --- | --- | --- |
-| `package-manager-packages` | All | A list of OS packages, such as `ftp gzip`, separated by line or space. |
-| `final-build-commands` | Final image | After all Image Tool actions are complete, and just before the container image is finalized. |
+| Section | Available Variables | Build Stage | Timing |
+| --- | --- | --- | --- |
+| `package-manager-packages` | None | All | A list of OS packages, such as `ftp gzip`, separated by line or space. |
+| `final-build-commands` | `AUXILIARY_IMAGE_PATH` `WDT_HOME` `WDT_MODEL_HOME`| Final image | After all Image Tool actions are complete, and just before the container image is finalized. |
 
 Each section can contain one or more valid Dockerfile commands and would look like the following:
 

--- a/documentation/1.11/content/userguide/tools/create-image.md
+++ b/documentation/1.11/content/userguide/tools/create-image.md
@@ -73,16 +73,16 @@ This is an advanced option that let's you provide additional commands to the Doc
 The input for this parameter is a simple text file that contains one or more of the valid sections.
 Valid sections for create are:
 
-| Section | Build Stage | Timing |
-| --- | --- | --- |
-| `package-manager-packages` | All | A list of OS packages, such as `ftp gzip`, separated by line or space. |
-| `before-jdk-install` | Intermediate (JDK_BUILD) | Before the JDK is installed. |
-| `after-jdk-install` | Intermediate (JDK_BUILD) | After the JDK is installed. |
-| `before-fmw-install` | Intermediate (WLS_BUILD) | Before the Oracle Home is created. |
-| `after-fmw-install` | Intermediate (WLS_BUILD) | After all of the Oracle middleware installers are finished. |
-| `before-wdt-command` | Intermediate (WDT_BUILD) | Before WDT is installed. |
-| `after-wdt-command` | Intermediate (WDT_BUILD) | After WDT domain creation/update is complete. |
-| `final-build-commands` | Final image | After all Image Tool actions are complete, and just before the container image is finalized. |
+| Section | Available Variables | Build Stage | Timing |
+| --- | --- | --- | --- |
+| `package-manager-packages` | None | All | A list of OS packages, such as `ftp gzip`, separated by line or space. |
+| `before-jdk-install` | `JAVA_HOME` | Intermediate (JDK_BUILD) | Before the JDK is installed. |
+| `after-jdk-install` | `JAVA_HOME` | Intermediate (JDK_BUILD) | After the JDK is installed. |
+| `before-fmw-install` | `JAVA_HOME` `ORACLE_HOME` | Intermediate (WLS_BUILD) | Before the Oracle Home is created. |
+| `after-fmw-install` | `JAVA_HOME` `ORACLE_HOME` | Intermediate (WLS_BUILD) | After all of the Oracle middleware installers are finished. |
+| `before-wdt-command` | `DOMAIN_HOME` | Intermediate (WDT_BUILD) | Before WDT is installed. |
+| `after-wdt-command` | `DOMAIN_HOME` | Intermediate (WDT_BUILD) | After WDT domain creation/update is complete. |
+| `final-build-commands` | `JAVA_HOME` `ORACLE_HOME` _`DOMAIN_HOME`_ | Final image | After all Image Tool actions are complete, and just before the container image is finalized. `DOMAIN_HOME` is only available if WDT was used during the build. |
 
 **NOTE**: Changes made in intermediate stages may not be carried forward to the final image unless copied manually.  
 The Image Tool will copy the Java Home, Oracle Home, domain home, and WDT home directories to the final image.  

--- a/documentation/1.11/content/userguide/tools/rebase-image.md
+++ b/documentation/1.11/content/userguide/tools/rebase-image.md
@@ -56,13 +56,13 @@ Usage: imagetool rebase [OPTIONS]
 This is an advanced option that let's you provide additional commands to the Docker build step.  
 The input for this parameter is a simple text file that contains one or more of the valid sections. Valid sections for rebase:
 
-| Section | Build Stage | Timing |
-| --- | --- | --- |
-| `before-jdk-install` | Intermediate (JDK_BUILD) | Before the JDK is installed. |
-| `after-jdk-install` | Intermediate (JDK_BUILD) | After the JDK is installed. |
-| `before-fmw-install` | Intermediate (WLS_BUILD) | Before the Oracle Home is created. |
-| `after-fmw-install` | Intermediate (WLS_BUILD) | After all of the Oracle middleware installers are finished. |
-| `final-build-commands` | Final image | After all Image Tool actions are complete, and just before the container image is finalized. |
+| Section | Available Variables | Build Stage | Timing |
+| --- | --- | --- | --- |
+| `before-jdk-install` | `JAVA_HOME` `DOMAIN_HOME`| Intermediate (JDK_BUILD) | Before the JDK is installed. |
+| `after-jdk-install` | `JAVA_HOME` `DOMAIN_HOME` | Intermediate (JDK_BUILD) | After the JDK is installed. |
+| `before-fmw-install` | `JAVA_HOME` `ORACLE_HOME` `DOMAIN_HOME` | Intermediate (WLS_BUILD) | Before the Oracle Home is created. |
+| `after-fmw-install` | `JAVA_HOME` `ORACLE_HOME` `DOMAIN_HOME` | Intermediate (WLS_BUILD) | After all of the Oracle middleware installers are finished. |
+| `final-build-commands` | `JAVA_HOME` `ORACLE_HOME` `DOMAIN_HOME` | Final image | After all Image Tool actions are complete, and just before the container image is finalized. |
 
 **NOTE**: Changes made in intermediate stages may not be carried forward to the final image unless copied manually.  
 The Image Tool will copy the Java Home and the Oracle Home directories to the final image.  

--- a/documentation/1.11/content/userguide/tools/update-image.md
+++ b/documentation/1.11/content/userguide/tools/update-image.md
@@ -72,11 +72,11 @@ Update WebLogic Docker image with selected patches
 This is an advanced option that let's you provide additional commands to the Docker build step.  
 The input for this parameter is a simple text file that contains one or more of the valid sections. Valid sections for update:
 
-| Section | Build Stage | Timing |
-| --- | --- | --- |
-| `before-wdt-command` | Intermediate (WDT_BUILD) | Before WDT is installed. |
-| `after-wdt-command` | Intermediate (WDT_BUILD) | After WDT domain creation/update is complete. |
-| `final-build-commands` | Final image | After all Image Tool actions are complete, and just before the container image is finalized. |
+| Section | Available Variables | Build Stage | Timing |
+| --- | --- | --- | --- |
+| `before-wdt-command` | `DOMAIN_HOME` | Intermediate (WDT_BUILD) | Before WDT is installed. |
+| `after-wdt-command` | `DOMAIN_HOME` | Intermediate (WDT_BUILD) | After WDT domain creation/update is complete. |
+| `final-build-commands` | `JAVA_HOME` `ORACLE_HOME` `DOMAIN_HOME` | Final image | After all Image Tool actions are complete, and just before the container image is finalized. |
 
 NOTE: Changes made in intermediate stages may not be carried forward to the final image unless copied manually.  
 The Image Tool will copy the domain home and the WDT home directories to the final image.  


### PR DESCRIPTION
Each stage of the container image build has different environment variables available.  This change documents which environment variables are available in which sections of the additional build commands.