### PR TITLE
allow usage of Mustache placeholders in additional build command file

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -75,8 +75,8 @@ public abstract class CommonOptions {
                 throw new FileNotFoundException(Utils.getMessage("IMG-0030", additionalBuildCommandsPath));
             }
 
-            AdditionalBuildCommands additionalBuildCommands = AdditionalBuildCommands.load(additionalBuildCommandsPath);
-            dockerfileOptions.setAdditionalBuildCommands(additionalBuildCommands.getContents());
+            AdditionalBuildCommands additionalBuildCommands = new AdditionalBuildCommands(additionalBuildCommandsPath);
+            dockerfileOptions.setAdditionalBuildCommands(additionalBuildCommands.getContents(dockerfileOptions));
         }
 
         if (additionalBuildFiles != null) {

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/AdditionalBuildCommands.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/AdditionalBuildCommands.java
@@ -5,6 +5,8 @@ package com.oracle.weblogic.imagetool.util;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.MessageFormat;
@@ -12,9 +14,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheFactory;
 import com.oracle.weblogic.imagetool.logging.LoggingFacade;
 import com.oracle.weblogic.imagetool.logging.LoggingFactory;
 
@@ -30,10 +36,16 @@ public class AdditionalBuildCommands {
     public static final String AFTER_WDT = "after-wdt-command";
     public static final String FINAL_BLD = "final-build-commands";
 
-    private List<NamedPattern> sections;
-    private Map<String, List<String>> contents;
+    private final List<NamedPattern> sections;
+    private final Map<String, List<String>> contents;
 
-    private AdditionalBuildCommands() {
+    /**
+     * Load the contents of the additional build commands file into this object.
+     * Existing data in this instance are replaced.
+     * @param file Path to the additional build commands file that should be loaded.
+     * @throws IOException if an issue occurs locating or opening the file provided
+     */
+    public AdditionalBuildCommands(Path file) throws IOException {
         sections = new ArrayList<>();
         sections.add(getPattern(PACKAGES));
         sections.add(getPattern(BEFORE_JDK));
@@ -43,6 +55,8 @@ public class AdditionalBuildCommands {
         sections.add(getPattern(BEFORE_WDT));
         sections.add(getPattern(AFTER_WDT));
         sections.add(getPattern(FINAL_BLD));
+        contents = new HashMap<>();
+        load(file);
     }
 
     private static NamedPattern getPattern(String key) {
@@ -61,8 +75,38 @@ public class AdditionalBuildCommands {
         return contents.size();
     }
 
-    public Map<String,List<String>> getContents() {
-        return contents;
+    /**
+     * Get the contents of the file provided on the command line as additional build commands.
+     * The file is parsed into a map based on the sections in the file. The returned map
+     * will have one entry per section found in the provided file (such as "final-build-commands").
+     * The Callable list value for each entry is for late resolution of the contents.  If the user
+     * provides mustache placeholders in the file, those placeholders will get resolved when the call
+     * method is invoked and not when getContents is returned.  This allows getContents to be called
+     * before DockerfileOptions is completely populated.
+     *
+     * @param options The backing file that will be used to resolve any mustache placeholders in the file
+     * @return a map by section name of the additional build file contents
+     */
+    public Map<String, Callable<List<String>>> getContents(DockerfileOptions options) {
+        Map<String, Callable<List<String>>> callableResult = new HashMap<>();
+        for (Map.Entry<String, List<String>> entry: contents.entrySet()) {
+            // implements the "call" method so that the contents are resolved at the time they are retrieved
+            Callable<List<String>> value = () -> {
+                List<String> resolvedLines = new ArrayList<>();
+                MustacheFactory mf = new DefaultMustacheFactory();
+                // Parse each line in the file contents using mustache and the provided "options"
+                for (String line: entry.getValue()) {
+                    StringWriter writer = new StringWriter();
+                    Mustache mustache = mf.compile(new StringReader(line), "x");
+                    mustache.execute(writer, options);
+                    writer.flush();
+                    resolvedLines.add(writer.toString());
+                }
+                return resolvedLines;
+            };
+            callableResult.put(entry.getKey(), value);
+        }
+        return callableResult;
     }
 
     /**
@@ -80,18 +124,15 @@ public class AdditionalBuildCommands {
      * @param file Path to the additional build commands file that should be loaded.
      * @throws IOException if an issue occurs locating or opening the file provided
      */
-    public static AdditionalBuildCommands load(Path file) throws IOException {
+    private void load(Path file) throws IOException {
         logger.entering(file);
-        AdditionalBuildCommands result = new AdditionalBuildCommands();
-        result.contents = new HashMap<>();
-
         try (BufferedReader reader = Files.newBufferedReader(file)) {
             List<String> buffer = new ArrayList<>();
             String currentSection = null;
             String line;
             while ((line = reader.readLine()) != null) {
                 logger.finest(line);
-                String sectionStart = result.checkForSectionHeader(line);
+                String sectionStart = checkForSectionHeader(line);
                 //skip any lines that come before the first section header
                 if (currentSection != null && sectionStart == null) {
                     //collect lines inside current section
@@ -99,7 +140,7 @@ public class AdditionalBuildCommands {
                 } else if (currentSection != null) {
                     //while in a section, found next section start (save last section, and start new section)
                     logger.fine("IMG-0015", buffer.size(), currentSection);
-                    result.contents.put(currentSection, buffer);
+                    contents.put(currentSection, buffer);
                     buffer = new ArrayList<>();
                     currentSection = sectionStart;
                 } else if (sectionStart != null) {
@@ -111,7 +152,7 @@ public class AdditionalBuildCommands {
             if (currentSection != null && !buffer.isEmpty()) {
                 //finished reading file, store the remaining lines that were read for the section
                 logger.fine("IMG-0015", buffer.size(), currentSection);
-                result.contents.put(currentSection, buffer);
+                contents.put(currentSection, buffer);
             }
         } catch (IOException ioe) {
             logger.severe("IMG-0013", file.getFileName());
@@ -119,7 +160,6 @@ public class AdditionalBuildCommands {
         }
 
         logger.exiting();
-        return result;
     }
 
     private String checkForSectionHeader(String line) {

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -112,3 +112,4 @@ IMG-0110=Retries exhausted, unable to obtain patch information from Oracle
 IMG-0111=The directory specified with WLSIMG_BLDDIR must exist prior to running this tool: {0}
 IMG-0112=The value specified with WLSIMG_BLDDIR must be a directory: {0}
 IMG-0113=The directory specified with WLSIMG_BLDDIR must be writable: {0}
+IMG-0114=Unable to parse section {0} of additionalBuildCommands: {1}

--- a/imagetool/src/test/resources/additionalBuildCommands/two-mustache.txt
+++ b/imagetool/src/test/resources/additionalBuildCommands/two-mustache.txt
@@ -1,0 +1,6 @@
+// Copyright 2022, Oracle Corporation and/or its affiliates.  All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
+
+[final-build-commands]
+echo This is the Oracle Home: {{{oracle_home}}}
+echo This is the Java Home: {{{java_home}}}


### PR DESCRIPTION
This change allows the usage of any existing template placeholders currently used by the build from within an additional build command file.  If the user specifies --additionalBuildCommands {file}, placeholders like {{java_home}} or {{oracle_home}} within the {file} provided were not previously resolved.  This change allows the usage of any of the existing placeholders used in the Image Tools templates to be used within the user's {file}.