### PR TITLE
Allow update image of 12.2.1.4 slim images

### DIFF
--- a/documentation/1.11/content/userguide/tools/update-image.md
+++ b/documentation/1.11/content/userguide/tools/update-image.md
@@ -23,47 +23,48 @@ Usage: imagetool update [OPTIONS]
 Update WebLogic Docker image with selected patches
 
 ```
-| Parameter | Definition | Default |
-| --- | --- | --- |
-| `--fromImage` | (Required) Container image to be extended. The provided image MUST contain an Oracle Home with middleware installed. The `fromImage` option serves as a starting point for the new image to be created. |   |
-| `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0`  |   |
-| `--additionalBuildCommands` | Path to a file with additional build commands. For more details, see [Additional information](#--additionalbuildcommands). |
-| `--additionalBuildFiles` | Additional files that are required by your `additionalBuildCommands`.  A comma separated list of files that should be copied to the build context. See [Additional information](#--additionalbuildfiles). |
-| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path. | `docker`  |
-| `--buildNetwork` | Networking mode for the RUN instructions during the image build.  See `--network` for Docker `build`.  |   |
-| `--chown` | `userid:groupid` for middleware patches and other operations.  | Owner:Group of the Oracle Home |
-| `--dryRun` | Skip Docker build execution and print the Dockerfile to stdout.  |  |
-| `--httpProxyUrl` | Proxy for the HTTP protocol. Example: `http://myproxy:80` or `http:user:passwd@myproxy:8080`  |   |
-| `--httpsProxyUrl` | Proxy for the HTTPS protocol. Example: `https://myproxy:80` or `https:user:passwd@myproxy:8080`  |   |
-| `--latestPSU` | (DEPRECATED) Find and apply the latest PatchSet Update, see [Additional information](#--latestpsu).  |   |
-| `--opatchBugNumber` | The patch number for OPatch (patching OPatch).  | `28186730`  |
-| `--password` | Request password for the Oracle Support `--user` on STDIN, see `--user`.  |   |
-| `--passwordEnv` | Environment variable containing the Oracle Support password, see `--user`.  |   |
-| `--passwordFile` | Path to a file containing just the Oracle Support password, see `--user`.  |   |
-| `--patches` | Comma separated list of patch IDs. Example: `12345678,87654321`  |   |
-| `--pull` | Always attempt to pull a newer version of base images during the build.  |   |
-| `--recommendedPatches` | (DEPRECATED) Find and apply the latest PatchSet Update and recommended patches. This takes precedence over `--latestPSU`. See [Additional information](#--recommendedpatches).  |   |
-| `--resourceTemplates` | One or more files containing placeholders that need to be resolved by the Image Tool. See [Resource Template Files](#resource-template-files). |   |
-| `--skipcleanup` | Do not delete the build context folder, intermediate images, and failed build containers. For debugging purposes.  |   |
-| `--strictPatchOrdering` |  Instruct OPatch to apply patches one at a time (uses `apply` instead of `napply`). |   |
-| `--target` | Select the target environment in which the created image will be used. Supported values: `Default` (Docker/Kubernetes), `OpenShift`. See [Additional information](#--target). | `Default`  |
-| `--user` | Oracle support email ID. When supplying `user`, you must supply the password either as an environment variable using `--passwordEnv`, or as a file using `--passwordFile`, or interactively, on the command line with `--password`.    |   |
-| `--wdtArchive` | A WDT archive ZIP file or comma-separated list of files.  |   |
-| `--wdtDomainHome` | Path to the `-domain_home` for WDT.  | `/u01/domains/base_domain`  |
-| `--wdtDomainType` | WDT domain type. Supported values: `WLS`, `JRF`, `RestrictedJRF`  | `WLS`  |
-| `--wdtEncryptionKey` | Passphrase for WDT -use_encryption that will be requested on STDIN. |   |
-| `--wdtEncryptionKeyEnv` | Passphrase for WDT -use_encryption that is provided as an environment variable. |   |
-| `--wdtEncryptionKeyFile` | Passphrase for WDT -use_encryption that is provided as a file. |   |
-| `--wdtHome` | The target folder in the image for the WDT install and models.  | `/u01/wdt`  |
-| `--wdtJavaOptions` | Java command-line options for WDT.  |   |
-| `--wdtModel` | A WDT model file or a comma-separated list of files.  |   |
-| `--wdtModelHome` | The target location in the image to copy WDT model, variable, and archive files. | `{wdtHome}/models` |
-| `--wdtModelOnly` | Install WDT and copy the models to the image, but do not create the domain.  | `false`  |
-| `--wdtOperation` | Create a new domain, or update an existing domain. Supported values: `CREATE`, `UPDATE`, `DEPLOY`  | `CREATE`  |
-| `--wdtRunRCU` | Instruct WDT to run RCU when creating the domain.  |   |
-| `--wdtStrictValidation` | Use strict validation for the WDT validation method. Only applies when using model only.  | `false`  |
-| `--wdtVariables` | A WDT variables file or comma-separated list of files.  |   |
-| `--wdtVersion` | WDT tool version to use.  |   |
+| Parameter | Definition                                                                                                                                                                                                                          | Default                        |
+| --- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------|
+| `--fromImage` | (Required) Container image to be extended. The provided image MUST contain an Oracle Home with middleware installed. The `fromImage` option serves as a starting point for the new image to be created.                             |                                |
+| `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0`                                                                                                                                               |                                |
+| `--additionalBuildCommands` | Path to a file with additional build commands. For more details, see [Additional information](#--additionalbuildcommands).                                                                                                          |
+| `--additionalBuildFiles` | Additional files that are required by your `additionalBuildCommands`.  A comma separated list of files that should be copied to the build context. See [Additional information](#--additionalbuildfiles).                           |
+| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path.                                                                                                                                      | `docker`                       |
+| `--buildNetwork` | Networking mode for the RUN instructions during the image build.  See `--network` for Docker `build`.                                                                                                                               |                                |
+| `--chown` | `userid:groupid` for middleware patches and other operations.                                                                                                                                                                       | Owner:Group of the Oracle Home |
+| `--dryRun` | Skip Docker build execution and print the Dockerfile to stdout.                                                                                                                                                                     |                                |
+| `--httpProxyUrl` | Proxy for the HTTP protocol. Example: `http://myproxy:80` or `http:user:passwd@myproxy:8080`                                                                                                                                        |                                |
+| `--httpsProxyUrl` | Proxy for the HTTPS protocol. Example: `https://myproxy:80` or `https:user:passwd@myproxy:8080`                                                                                                                                     |                                |
+| `--latestPSU` | (DEPRECATED) Find and apply the latest PatchSet Update, see [Additional information](#--latestpsu).                                                                                                                                 |                                |
+| `--opatchBugNumber` | The patch number for OPatch (patching OPatch).                                                                                                                                                                                      | `28186730`                     |
+| `--password` | Request password for the Oracle Support `--user` on STDIN, see `--user`.                                                                                                                                                            |                                |
+| `--passwordEnv` | Environment variable containing the Oracle Support password, see `--user`.                                                                                                                                                          |                                |
+| `--passwordFile` | Path to a file containing just the Oracle Support password, see `--user`.                                                                                                                                                           |                                |
+| `--patches` | Comma separated list of patch IDs. Example: `12345678,87654321`                                                                                                                                                                     |                                |
+| `--pull` | Always attempt to pull a newer version of base images during the build.                                                                                                                                                             |                                |
+| `--recommendedPatches` | (DEPRECATED) Find and apply the latest PatchSet Update and recommended patches. This takes precedence over `--latestPSU`. See [Additional information](#--recommendedpatches).                                                      |                                |
+| `--resourceTemplates` | One or more files containing placeholders that need to be resolved by the Image Tool. See [Resource Template Files](#resource-template-files).                                                                                      |                                |
+| `--skipcleanup` | Do not delete the build context folder, intermediate images, and failed build containers. For debugging purposes.                                                                                                                   |                                |
+| `--strictPatchOrdering` | Instruct OPatch to apply patches one at a time (uses `apply` instead of `napply`).                                                                                                                                                  |                                |
+| `--target` | Select the target environment in which the created image will be used. Supported values: `Default` (Docker/Kubernetes), `OpenShift`. See [Additional information](#--target).                                                       | `Default`                      |
+| `--type` | Installer type. Supported values: `WLS`, `WLSDEV`, `WLSSLIM`, `FMW`, `IDM`, `OSB`, `OUD_WLS`, `SOA_OSB`, `SOA_OSB_B2B`, `MFT`, `WCP`, `OAM`, `OIG`, `OUD`, `OID`, `SOA`, `WCC`, `WCS`, `WCP`                                        | Installer used in `fromImage`  |
+| `--user` | Oracle support email ID. When supplying `user`, you must supply the password either as an environment variable using `--passwordEnv`, or as a file using `--passwordFile`, or interactively, on the command line with `--password`.   |                                |
+| `--wdtArchive` | A WDT archive ZIP file or comma-separated list of files.                                                                                                                                                                            |                                |
+| `--wdtDomainHome` | Path to the `-domain_home` for WDT.                                                                                                                                                                                                 | `/u01/domains/base_domain`     |
+| `--wdtDomainType` | WDT domain type. Supported values: `WLS`, `JRF`, `RestrictedJRF`                                                                                                                                                                    | `WLS`                          |
+| `--wdtEncryptionKey` | Passphrase for WDT -use_encryption that will be requested on STDIN.                                                                                                                                                                 |                                |
+| `--wdtEncryptionKeyEnv` | Passphrase for WDT -use_encryption that is provided as an environment variable.                                                                                                                                                     |                                |
+| `--wdtEncryptionKeyFile` | Passphrase for WDT -use_encryption that is provided as a file.                                                                                                                                                                      |                                |
+| `--wdtHome` | The target folder in the image for the WDT install and models.                                                                                                                                                                      | `/u01/wdt`                     |
+| `--wdtJavaOptions` | Java command-line options for WDT.                                                                                                                                                                                                  |                                |
+| `--wdtModel` | A WDT model file or a comma-separated list of files.                                                                                                                                                                                |                                |
+| `--wdtModelHome` | The target location in the image to copy WDT model, variable, and archive files.                                                                                                                                                    | `{wdtHome}/models`             |
+| `--wdtModelOnly` | Install WDT and copy the models to the image, but do not create the domain.                                                                                                                                                         | `false`                        |
+| `--wdtOperation` | Create a new domain, or update an existing domain. Supported values: `CREATE`, `UPDATE`, `DEPLOY`                                                                                                                                   | `CREATE`                       |
+| `--wdtRunRCU` | Instruct WDT to run RCU when creating the domain.                                                                                                                                                                                   |                                |
+| `--wdtStrictValidation` | Use strict validation for the WDT validation method. Only applies when using model only.                                                                                                                                            | `false`                        |
+| `--wdtVariables` | A WDT variables file or comma-separated list of files.                                                                                                                                                                              |                                |
+| `--wdtVersion` | WDT tool version to use.                                                                                                                                                                                                            |                                |
 
 ### Additional information
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonCreateOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonCreateOptions.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.menu;
@@ -11,7 +11,6 @@ import javax.xml.xpath.XPathExpressionException;
 
 import com.oracle.weblogic.imagetool.api.model.CachedFile;
 import com.oracle.weblogic.imagetool.aru.AruException;
-import com.oracle.weblogic.imagetool.installer.FmwInstallerType;
 import com.oracle.weblogic.imagetool.installer.InstallerType;
 import com.oracle.weblogic.imagetool.installer.MiddlewareInstall;
 import com.oracle.weblogic.imagetool.logging.LoggingFacade;
@@ -42,7 +41,7 @@ public class CommonCreateOptions extends CommonPatchingOptions {
 
         if (dockerfileOptions.installMiddleware()) {
             MiddlewareInstall install =
-                new MiddlewareInstall(installerType, installerVersion, installerResponseFiles);
+                new MiddlewareInstall(getInstallerType(), installerVersion, installerResponseFiles);
             install.copyFiles(cache(), buildDir());
             dockerfileOptions.setMiddlewareInstall(install);
         } else {
@@ -50,7 +49,7 @@ public class CommonCreateOptions extends CommonPatchingOptions {
         }
 
         // resolve required patches
-        handlePatchFiles(installerType);
+        handlePatchFiles();
 
         // If patching, patch OPatch first
         if (applyingPatches() && shouldUpdateOpatch()) {
@@ -75,12 +74,6 @@ public class CommonCreateOptions extends CommonPatchingOptions {
     String getInstallerVersion() {
         return installerVersion;
     }
-
-    @Option(
-        names = {"--type"},
-        description = "Installer type. Default: WLS. Supported values: ${COMPLETION-CANDIDATES}"
-    )
-    private FmwInstallerType installerType = FmwInstallerType.WLS;
 
     @Option(
         names = {"--version"},

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2019, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.menu;
@@ -250,7 +250,7 @@ public abstract class CommonOptions {
         return isOptionSet("--chown");
     }
 
-    private boolean isOptionSet(String optionName) {
+    boolean isOptionSet(String optionName) {
         CommandLine.ParseResult pr = spec.commandLine().getParseResult();
         return pr.hasMatchedOption(optionName);
     }

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonPatchingOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonPatchingOptions.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2019, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.menu;
@@ -39,6 +39,20 @@ public abstract class CommonPatchingOptions extends CommonOptions {
 
     abstract String getInstallerVersion();
 
+    /**
+     * Get the installer type selected by the user.
+     * This method is overridden by UpdateImage to provide the installer type
+     * from the fromImage.
+     * @return WLS by default, or the value selected by the user on the command line.
+     */
+    FmwInstallerType getInstallerType() {
+        return installerType;
+    }
+
+    boolean isInstallerTypeSet() {
+        return isOptionSet("--type");
+    }
+
     @Override
     void initializeOptions() throws IOException, InvalidCredentialException, InvalidPatchIdFormatException {
         super.initializeOptions();
@@ -63,6 +77,15 @@ public abstract class CommonPatchingOptions extends CommonOptions {
     }
 
     /**
+     * Returns true if latestPsu or recommendedPatches was requested.
+     *
+     * @return true if applying patches
+     */
+    boolean applyingLatestPsu() {
+        return (latestPsu || recommendedPatches);
+    }
+
+    /**
      * Should OPatch version be updated.
      * OPatch should be updated to the latest version available unless the user
      * requests that OPatch should not be updated.
@@ -75,9 +98,18 @@ public abstract class CommonPatchingOptions extends CommonOptions {
         return !skipOpatchUpdate;
     }
 
-    void handlePatchFiles(FmwInstallerType installerType) throws AruException, XPathExpressionException, IOException {
+    /**
+     * Process all patches requested by the user, if any.
+     * Downloads and copies patch JARs to the build context directory.
+     *
+     * @throws AruException     if an error occurs trying to read patch metadata from ARU.
+     * @throws IOException      if a transport error occurs trying to access the Oracle REST services.
+     * @throws XPathExpressionException when the payload from the REST service is not formatted as expected
+     *                          or a partial response was returned.
+     */
+    void handlePatchFiles() throws AruException, XPathExpressionException, IOException {
         if (dockerfileOptions.installMiddleware()) {
-            handlePatchFiles(installerType, Collections.emptyList());
+            handlePatchFiles(Collections.emptyList());
         } else {
             if (applyingPatches()) {
                 // user intended to apply patches, but used a fromImage that already had an Oracle Home
@@ -91,23 +123,22 @@ public abstract class CommonPatchingOptions extends CommonOptions {
      * Process all patches requested by the user, if any.
      * Downloads and copies patch JARs to the build context directory.
      *
-     * @param installerType     The installer type used to create the Oracle Home
      * @param installedPatches  a list of patches applied already installed on the target image.
      * @throws AruException     if an error occurs trying to read patch metadata from ARU.
      * @throws IOException      if a transport error occurs trying to access the Oracle REST services.
      * @throws XPathExpressionException when the payload from the REST service is not formatted as expected
      *                          or a partial response was returned.
      */
-    void handlePatchFiles(FmwInstallerType installerType, List<InstalledPatch> installedPatches)
+    void handlePatchFiles(List<InstalledPatch> installedPatches)
         throws AruException, IOException, XPathExpressionException {
-        logger.entering(installerType, installedPatches);
-        String psuVersion = InstalledPatch.getPsuVersion(installedPatches);
+        logger.entering(getInstallerType(), installedPatches);
         if (!applyingPatches()) {
             logger.exiting("not applying patches");
             return;
         }
+        String psuVersion = InstalledPatch.getPsuVersion(installedPatches);
 
-        List<AruPatch> aruPatches = getRecommendedPatchList(installerType);
+        List<AruPatch> aruPatches = getRecommendedPatchList();
 
         if (!aruPatches.isEmpty()) {
             // when applying a new PSU, use that PSU version to find patches where user did not qualify the patch number
@@ -192,7 +223,7 @@ public abstract class CommonPatchingOptions extends CommonOptions {
      * @return recommended patch list or empty list if neither latestPSU nor recommendedPatches was requested
      *         by the user.
      */
-    List<AruPatch> getRecommendedPatchList(FmwInstallerType installerType) throws AruException {
+    List<AruPatch> getRecommendedPatchList() throws AruException {
         List<AruPatch> aruPatches = new ArrayList<>();
         if (recommendedPatches || latestPsu) {
             if (userId == null || password == null) {
@@ -202,12 +233,12 @@ public abstract class CommonPatchingOptions extends CommonOptions {
             if (recommendedPatches) {
                 // Get the latest PSU and its recommended patches
                 aruPatches = AruUtil.rest()
-                    .getRecommendedPatches(installerType, getInstallerVersion(), userId, password);
+                    .getRecommendedPatches(getInstallerType(), getInstallerVersion(), userId, password);
 
                 if (aruPatches.isEmpty()) {
                     recommendedPatches = false;
                     logger.info("IMG-0084", getInstallerVersion());
-                } else if (FmwInstallerType.isBaseWeblogicServer(installerType)) {
+                } else if (FmwInstallerType.isBaseWeblogicServer(getInstallerType())) {
                     // find and remove all ADR patches in the recommended patches list for base WLS installers
                     List<AruPatch> discard = aruPatches.stream()
                         .filter(p -> p.description().startsWith("ADR FOR WEBLOGIC SERVER"))
@@ -218,7 +249,7 @@ public abstract class CommonPatchingOptions extends CommonOptions {
                 }
             } else {
                 // PSUs for WLS and JRF installers are considered WLS patches
-                aruPatches = AruUtil.rest().getLatestPsu(installerType, getInstallerVersion(), userId, password);
+                aruPatches = AruUtil.rest().getLatestPsu(getInstallerType(), getInstallerVersion(), userId, password);
 
                 if (aruPatches.isEmpty()) {
                     latestPsu = false;
@@ -292,19 +323,19 @@ public abstract class CommonPatchingOptions extends CommonOptions {
         names = {"--latestPSU"},
         description = "Whether to apply patches from latest PSU."
     )
-    boolean latestPsu = false;
+    private boolean latestPsu = false;
 
     @Option(
         names = {"--recommendedPatches"},
         description = "Whether to apply recommended patches from latest PSU."
     )
-    boolean recommendedPatches = false;
+    private boolean recommendedPatches = false;
 
     @Option(
         names = {"--strictPatchOrdering"},
         description = "Use OPatch to apply patches one at a time."
     )
-    boolean strictPatchOrdering = false;
+    private boolean strictPatchOrdering = false;
 
     @Option(
         names = {"--patches"},
@@ -325,4 +356,10 @@ public abstract class CommonPatchingOptions extends CommonOptions {
         description = "Do not update OPatch version, even if a newer version is available."
     )
     private boolean skipOpatchUpdate = false;
+
+    @Option(
+        names = {"--type"},
+        description = "Installer type. Default: WLS. Supported values: ${COMPLETION-CANDIDATES}"
+    )
+    private FmwInstallerType installerType = FmwInstallerType.WLS;
 }

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -7,7 +7,7 @@ IMG-0005=Installer response file: {0}
 IMG-0006=No patch conflicts detected
 IMG-0007={0} is not a directory
 IMG-0008=Updating OPatch in final image from version {0} to version {1}
-IMG-0009=Skipping patch conflict check, no support credentials provided
+IMG-0009=No credentials provided, skipping patch conflict check.
 IMG-0010=Oracle Home will be set to [[cyan: {0}]]
 IMG-0011=Installer with key="{0}" is not in the local cache, please download the installer and add it to the cache with "imagetool cache addInstaller ..."
 IMG-0012=Checking for conflicting patches
@@ -94,7 +94,7 @@ IMG-0092=ORACLE_HOME already exists in {0} (--fromImage), skipping middleware in
 IMG-0093=Patching skipped.  Using CREATE to patch --fromImage with an existing ORACLE_HOME is not supported. To create a patched image, use CREATE with a linux base image and apply the WebLogic install and patches at the same time.
 IMG-0094=Source image installer type: ([[green: {0}]])
 IMG-0095=Unable to parse response for Oracle patches in fromImage: {0}
-IMG-0096=Unable to patch image {0}. The installed products could not be identified for patching. The most likely cause is that the registry.xml in this image may be invalid.
+IMG-0096=Unable to determine installed products in image {0}. The most likely cause is that the registry.xml in this image may be invalid. Defaulting installer type to [[green: WLS]].
 IMG-0097=Inspecting {0}, this may take a few minutes if the image is not available locally.
 IMG-0098=Patch [[red: {0}]] is a Stack Patch Bundle, not a patch. Remove {0} from --patches and use [[cyan: --recommendedPatches]] instead.
 IMG-0099=Found patch [[cyan: {0}]] for version [[cyan: {1}]]. Bug description: "{2}"

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/cli/menu/CommonPatchingOptionsTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/cli/menu/CommonPatchingOptionsTest.java
@@ -138,7 +138,7 @@ class CommonPatchingOptionsTest {
         aruRest.setAccessible(true);
         aruRest.set(aruRest, new CommonPatchingOptionsTest.TestAruUtil());
 
-        List<AruPatch> patches = createImage.getRecommendedPatchList(FmwInstallerType.WLS);
+        List<AruPatch> patches = createImage.getRecommendedPatchList();
         assertTrue(patches.isEmpty(), "Neither latestPSU nor recommendedPatches was specified, but returned patches");
     }
 
@@ -154,7 +154,7 @@ class CommonPatchingOptionsTest {
         aruRest.set(aruRest, new CommonPatchingOptionsTest.TestAruUtil());
 
         createImage.initializeOptions();
-        List<AruPatch> patches = createImage.getRecommendedPatchList(FmwInstallerType.WLS);
+        List<AruPatch> patches = createImage.getRecommendedPatchList();
         assertFalse(patches.isEmpty(), "recommendedPatches was specified, but returned patches was empty");
         assertEquals(2, patches.size(),"ADR patch was not removed?");
     }
@@ -171,7 +171,7 @@ class CommonPatchingOptionsTest {
         aruRest.set(aruRest, new CommonPatchingOptionsTest.TestAruUtil());
 
         createImage.initializeOptions();
-        assertThrows(IllegalArgumentException.class, () -> createImage.getRecommendedPatchList(FmwInstallerType.WLS));
+        assertThrows(IllegalArgumentException.class, createImage::getRecommendedPatchList);
     }
 
 }


### PR DESCRIPTION
The Quick Slim installer for WLS 12.2.1.4 has a bug that causes the registry.xml not to be created during install.  `UpdateImage` uses registry.xml to determine the installer type that was used to create the image to be updated.  If no registry.xml file is found, `UpdateImage` exits with an error.

This change allows updates of images without a registry.xml.  The default installer type for `UpdateImage` is now WLS, and the user can override that default with the command line option, `--type`.