### PR TITLE
create and allow openshift users to access WDT logs directory when target is OpenShift

### DIFF
--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -106,7 +106,7 @@ IMG-0104=You must provide at least one of: a WDT installer file, a WDT model fil
 IMG-0105=Installer version cannot use keyword of 'none'.
 IMG-0106=Failed to get response from patches server, {0}, retrying [{1}/{2}]
 IMG-0107=Failed to download and save file {0} from {1}: {2}
-IMG-0108=Environment variable {0}=`{1}` is not an integer and will be ignored.
+IMG-0108=Environment variable {0}="{1}" is not an integer and will be ignored.
 IMG-0109=Invalid value found in {0}.  {1} < {2}.  Using default value: {3}.
 IMG-0110=Retries exhausted, unable to obtain patch information from Oracle
 IMG-0111=The directory specified with WLSIMG_BLDDIR must exist prior to running this tool: {0}

--- a/imagetool/src/main/resources/docker-files/run-wdt.mustache
+++ b/imagetool/src/main/resources/docker-files/run-wdt.mustache
@@ -68,12 +68,14 @@ RUN test -d {{{wdt_home}}}/weblogic-deploy && rm -rf {{{wdt_home}}}/weblogic-dep
     && rm ./*.cmd \
     {{#domainGroupAsUser}}
         && chmod -R g=u {{{wdt_home}}}/weblogic-deploy/lib \
+        && mkdir {{{wdt_home}}}/weblogic-deploy/logs \
+        && chmod g=u {{{wdt_home}}}/weblogic-deploy/logs \
     {{/domainGroupAsUser}}
     && ./validateModel.sh {{^strictValidation}}-method lax{{/strictValidation}} \
     -oracle_home {{{oracle_home}}} \
     -domain_type {{domainType}} \
     {{{wdtVariableFileArgument}}} {{{wdtModelFileArgument}}} {{{wdtArchiveFileArgument}}} \
-    && rm -rf {{{wdt_home}}}/weblogic-deploy/logs \
+    && rm {{{wdt_home}}}/weblogic-deploy/logs/* \
     && shopt -s globstar && rm -f {{{wdt_home}}}/weblogic-deploy/lib/python/**/*.class
 {{/isWdtValidateEnabled}}
 


### PR DESCRIPTION
OpenShift certification is failing due to the WKO creating the WDT logs in the wrong folder due to lack of permissions.