### PR TITLE
Fixed bug in REBASE that prevented copy of WDT_HOME

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/RebaseImage.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2019, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package com.oracle.weblogic.imagetool.cli.menu;

--- a/imagetool/src/main/resources/ImageTool.properties
+++ b/imagetool/src/main/resources/ImageTool.properties
@@ -88,7 +88,7 @@ IMG-0086=Failed to find patch number [[brightred: {0}]] on Oracle servers, verif
 IMG-0087=The Oracle Home directory in --fromImage={0} has an owner and group of {1}:{2}.  You must update the image with the same user and group setting from when it was created. Example: --chown={1}:{2}
 IMG-0088=Build command failed with error: {0}
 IMG-0089=WDT_MODEL_HOME was not set in the source image, using default model location: {0}
-IMG-0090=Rebasing WDT models.  A domain was not found in the source image at {0}
+IMG-0090=Rebasing WDT models only.  A domain was not found in the source image at {0}
 IMG-0091=Reading settings from the source image {0}
 IMG-0092=ORACLE_HOME already exists in {0} (--fromImage), skipping middleware installs
 IMG-0093=Patching skipped.  Using CREATE to patch --fromImage with an existing ORACLE_HOME is not supported. To create a patched image, use CREATE with a linux base image and apply the WebLogic install and patches at the same time.
@@ -115,3 +115,4 @@ IMG-0113=The directory specified with WLSIMG_BLDDIR must be writable: {0}
 IMG-0114=Unable to parse section {0} of additionalBuildCommands: {1}
 IMG-0115=Unable to reach Oracle patch server to check for patch conflicts, skipping online conflict check. OPatch will check patches locally during the build.
 IMG-0116=A patch conflict was detected. The patches listed within the brackets conflict with each other. These fixes cannot be applied without a merge patch from Oracle:
+IMG-0117=The value for --sourceImage must not be empty.


### PR DESCRIPTION
Fixes #366. When copying modelOnly from old to new container image, WDT_HOME was not being populated after inspection of the source image.

Additionally, the file ownership for the domain and models was incorrectly using the default values instead of reading the value from the target container image.