### PR TITLE
Added releasePackage attribute to INSPECT image.

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/inspect/InspectOutput.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/inspect/InspectOutput.java
@@ -73,6 +73,9 @@ public class InspectOutput {
             result.append(jsonKeyValuePair(2, "id", os.id())).append(",\n");
             result.append(jsonKeyValuePair(2, "name", os.name())).append(",\n");
             result.append(jsonKeyValuePair(2, "version", os.version())).append("\n");
+            if (os.releasePackage() != null) {
+                result.append(jsonKeyValuePair(2, "releasePackage", os.releasePackage())).append("\n");
+            }
             result.append(pad(1)).append("},");
             result.append('\n');
         }

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/inspect/OperatingSystemProperties.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/inspect/OperatingSystemProperties.java
@@ -11,6 +11,7 @@ public class OperatingSystemProperties {
     private String id;
     private String version;
     private String name;
+    private String releasePackage;
 
     public String id() {
         return id;
@@ -22,6 +23,10 @@ public class OperatingSystemProperties {
 
     public String name() {
         return name;
+    }
+
+    public String releasePackage() {
+        return releasePackage;
     }
 
     /**
@@ -37,6 +42,7 @@ public class OperatingSystemProperties {
             result.version = removeQuotes(imageProperties.getProperty("__OS__VERSION_ID"));
         }
         result.name = removeQuotes(imageProperties.getProperty("__OS__NAME"));
+        result.releasePackage = imageProperties.getProperty("__OS__RELEASE_PACKAGE");
         return result;
     }
 

--- a/imagetool/src/main/resources/probe-env/inspect-image-long.sh
+++ b/imagetool/src/main/resources/probe-env/inspect-image-long.sh
@@ -86,6 +86,10 @@ fi
 
 if [ -f "/etc/os-release" ]; then
   grep '=' /etc/os-release | sed 's/^/__OS__/'
+    releasePackage="$(type rpm >/dev/null 2>&1  && rpm -qf /etc/os-release || echo '')"
+    if [ -n "$releasePackage" ]; then
+      echo __OS__RELEASE_PACKAGE=$releasePackage
+    fi
 elif type busybox > /dev/null 2>&1; then
   echo __OS__ID="bb"
   echo __OS__NAME="$(busybox | head -1 | awk '{ print $1 }')"

--- a/imagetool/src/main/resources/probe-env/inspect-image.sh
+++ b/imagetool/src/main/resources/probe-env/inspect-image.sh
@@ -66,6 +66,10 @@ fi
 
 if [ -f "/etc/os-release" ]; then
   grep '=' /etc/os-release | sed 's/^/__OS__/'
+  releasePackage="$(type rpm >/dev/null 2>&1  && rpm -qf /etc/os-release || echo '')"
+  if [ -n "$releasePackage" ]; then
+    echo __OS__RELEASE_PACKAGE=$releasePackage
+  fi
 elif type busybox > /dev/null 2>&1; then
   echo __OS__ID="bb"
   echo __OS__NAME="$(busybox | head -1 | awk '{ print $1 }')"


### PR DESCRIPTION
If available, INSPECT will include `releasePackage` as an attribute for the OS.  The release package is the package name for the file /etc/os-release.  For the time-being, the usefulness of this attribute may be limited to Oracle Linux.
  
"os" : {
    "id" : "ol",
    "name" : "Oracle Linux Server",
    "version" : "7.9"
    "releasePackage" : "oraclelinux-release-7.9-1.0.9.el7.x86_64"
  },