### PR TITLE
Fixed invalid output for INSPECT of Oracle Linux images. Missing comma in OS object.

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/inspect/InspectOutput.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/inspect/InspectOutput.java
@@ -72,9 +72,12 @@ public class InspectOutput {
             result.append(pad(1)).append('\"').append("os").append('\"').append(" : {\n");
             result.append(jsonKeyValuePair(2, "id", os.id())).append(",\n");
             result.append(jsonKeyValuePair(2, "name", os.name())).append(",\n");
-            result.append(jsonKeyValuePair(2, "version", os.version())).append("\n");
+            result.append(jsonKeyValuePair(2, "version", os.version()));
             if (os.releasePackage() != null) {
+                result.append(",\n");
                 result.append(jsonKeyValuePair(2, "releasePackage", os.releasePackage())).append("\n");
+            } else {
+                result.append("\n");
             }
             result.append(pad(1)).append("},");
             result.append('\n');

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/inspect/OperatingSystemProperties.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/inspect/OperatingSystemProperties.java
@@ -42,7 +42,7 @@ public class OperatingSystemProperties {
             result.version = removeQuotes(imageProperties.getProperty("__OS__VERSION_ID"));
         }
         result.name = removeQuotes(imageProperties.getProperty("__OS__NAME"));
-        result.releasePackage = imageProperties.getProperty("__OS__RELEASE_PACKAGE");
+        result.releasePackage = removeQuotes(imageProperties.getProperty("__OS__RELEASE_PACKAGE"));
         return result;
     }
 

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/inspect/InspectTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/inspect/InspectTest.java
@@ -31,6 +31,12 @@ class InspectTest {
             "src/test/resources/inspect/image2.json");
     }
 
+    @Test
+    void testMoreProperties() throws IOException {
+        testPropertiesToJson("src/test/resources/inspect/image3.properties",
+            "src/test/resources/inspect/image3.json");
+    }
+
     void testPropertiesToJson(String propsFile, String jsonFile) throws IOException {
         Properties loaded = new Properties();
         try (InputStream input = new FileInputStream(propsFile)) {

--- a/imagetool/src/test/resources/inspect/image3.json
+++ b/imagetool/src/test/resources/inspect/image3.json
@@ -1,0 +1,19 @@
+{
+  "oraclePatches" : [
+  ],
+  "os" : {
+    "id" : "ol",
+    "name" : "Oracle Linux Server",
+    "version" : "7.9",
+    "releasePackage" : "oraclelinux-release-7.9-1.0.7.el8.x86_64"
+  },
+  "domainHome" : "/u01/domains/base_domain",
+  "javaHome" : "/u01/jdk",
+  "javaVersion" : "1.8.0_202",
+  "opatchVersion" : "13.9.4.2.1",
+  "oracleHome" : "/u01/oracle",
+  "oracleHomeGroup" : "oracle",
+  "oracleHomeUser" : "oracle",
+  "packageManager" : "YUM",
+  "wlsVersion" : "12.2.1.4.0"
+}

--- a/imagetool/src/test/resources/inspect/image3.properties
+++ b/imagetool/src/test/resources/inspect/image3.properties
@@ -1,0 +1,17 @@
+# Copyright (c) 2021, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+oraclePatches=
+oracleHome=/u01/oracle
+domainHome=/u01/domains/base_domain
+javaVersion=1.8.0_202
+oracleHomeGroup=oracle
+oracleHomeUser=oracle
+opatchVersion=13.9.4.2.1
+packageManager=YUM
+wlsVersion=12.2.1.4.0
+javaHome=/u01/jdk
+__OS__NAME="Oracle Linux Server"
+__OS__VERSION="7.9"
+__OS__ID="ol"
+__OS__RELEASE_PACKAGE="oraclelinux-release-7.9-1.0.7.el8.x86_64"


### PR DESCRIPTION
Fixed the missing comma after the version attribute in OS

```json
"os" : {
    "id" : "ol",
    "name" : "Oracle Linux Server",
    "version" : "8.5",
    "releasePackage" : "oraclelinux-release-8.5-1.0.7.el8.x86_64"
},
```
