### PR TITLE
--additionalBuildFiles should print child file path not being copied

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Utils.java
@@ -116,7 +116,7 @@ public class Utils {
                 } else if (Files.isRegularFile(child)) {
                     copyLocalFile(child, destPath.resolve(child.getFileName()));
                 } else {
-                    logger.info("IMG-0035", sourcePath.toString());
+                    logger.info("IMG-0035", child.toString());
                 }
             }
         }


### PR DESCRIPTION
While using the `--additionalBuildFiles` option it was observed that certain files were not getting copied and the tool was printing always the source directory name and not the actual file name/path that could not be copied. This PR to fix that.