### PR TITLE
When '--builder' isn't specified, use the WLSIMG_BUILDER env var...

### DIFF
--- a/documentation/1.11/content/userguide/tools/create-aux-image.md
+++ b/documentation/1.11/content/userguide/tools/create-aux-image.md
@@ -24,7 +24,7 @@ Usage: imagetool createAuxImage [OPTIONS]
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/mydomain:1`  |   |
 | `--additionalBuildCommands` | Path to a file with additional build commands. For more details, see [Additional information](#--additionalbuildcommands). |
 | `--additionalBuildFiles` | Additional files that are required by your `additionalBuildCommands`.  A comma separated list of files that should be copied to the build context. See [Additional information](#--additionalbuildfiles). |
-| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path. | `docker`  |
+| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path. | Defaults to 'docker', or, when set, to the value in environment variable WLSIMG_BUILDER. |
 | `--buildNetwork` | Networking mode for the RUN instructions during the image build.  See `--network` for Docker `build`.  |   |
 | `--chown` | `userid:groupid` for JDK/Middleware installs and patches.  | `oracle:oracle` |
 | `--dryRun` | Skip Docker build execution and print the Dockerfile to stdout.  |  |

--- a/documentation/1.11/content/userguide/tools/create-aux-image.md
+++ b/documentation/1.11/content/userguide/tools/create-aux-image.md
@@ -24,7 +24,7 @@ Usage: imagetool createAuxImage [OPTIONS]
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/mydomain:1`  |   |
 | `--additionalBuildCommands` | Path to a file with additional build commands. For more details, see [Additional information](#--additionalbuildcommands). |
 | `--additionalBuildFiles` | Additional files that are required by your `additionalBuildCommands`.  A comma separated list of files that should be copied to the build context. See [Additional information](#--additionalbuildfiles). |
-| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path. | Defaults to 'docker', or, when set, to the value in environment variable WLSIMG_BUILDER. |
+| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path. | Defaults to `docker`, or, when set, to the value in environment variable `WLSIMG_BUILDER`. |
 | `--buildNetwork` | Networking mode for the RUN instructions during the image build.  See `--network` for Docker `build`.  |   |
 | `--chown` | `userid:groupid` for JDK/Middleware installs and patches.  | `oracle:oracle` |
 | `--dryRun` | Skip Docker build execution and print the Dockerfile to stdout.  |  |

--- a/documentation/1.11/content/userguide/tools/create-image.md
+++ b/documentation/1.11/content/userguide/tools/create-image.md
@@ -21,7 +21,7 @@ Usage: imagetool create [OPTIONS]
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0`  |   |
 | `--additionalBuildCommands` | Path to a file with additional build commands. For more details, see [Additional information](#--additionalbuildcommands). |
 | `--additionalBuildFiles` | Additional files that are required by your `additionalBuildCommands`.  A comma separated list of files that should be copied to the build context. See [Additional information](#--additionalbuildfiles). |
-| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path. | `docker`  |
+| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path. | Defaults to 'docker', or, when set, to the value in environment variable WLSIMG_BUILDER. |
 | `--buildNetwork` | Networking mode for the RUN instructions during the image build.  See `--network` for Docker `build`.  |   |
 | `--chown` | `userid:groupid` for JDK/Middleware installs and patches.  | `oracle:oracle` |
 | `--docker` | (DEPRECATED) Path to the Docker executable. Use `--builder` instead.  |  `docker` |

--- a/documentation/1.11/content/userguide/tools/create-image.md
+++ b/documentation/1.11/content/userguide/tools/create-image.md
@@ -21,7 +21,7 @@ Usage: imagetool create [OPTIONS]
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0`  |   |
 | `--additionalBuildCommands` | Path to a file with additional build commands. For more details, see [Additional information](#--additionalbuildcommands). |
 | `--additionalBuildFiles` | Additional files that are required by your `additionalBuildCommands`.  A comma separated list of files that should be copied to the build context. See [Additional information](#--additionalbuildfiles). |
-| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path. | Defaults to 'docker', or, when set, to the value in environment variable WLSIMG_BUILDER. |
+| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path. | Defaults to `docker`, or, when set, to the value in environment variable `WLSIMG_BUILDER`. |
 | `--buildNetwork` | Networking mode for the RUN instructions during the image build.  See `--network` for Docker `build`.  |   |
 | `--chown` | `userid:groupid` for JDK/Middleware installs and patches.  | `oracle:oracle` |
 | `--docker` | (DEPRECATED) Path to the Docker executable. Use `--builder` instead.  |  `docker` |

--- a/documentation/1.11/content/userguide/tools/inspect-image.md
+++ b/documentation/1.11/content/userguide/tools/inspect-image.md
@@ -16,7 +16,7 @@ Usage: imagetool inspect [OPTIONS]
 | Parameter | Definition | Default |
 | --- | --- | --- |
 | `--image`, `-i` | (Required) The image ID or image name to be inspected.  |   |
-| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path. | `docker`  |
+| `--builder`, `-b` | Executable to inspect docker images. Use the full path of the executable if not on your path. | Defaults to 'docker', or, when set, to the value in environment variable WLSIMG_BUILDER. |
 | `--format` | The output format. Supported values: `JSON` | `JSON`  |
 | `--patches` | Include OPatch information in the output, including a list of WebLogic patches that are applied.  |   |
 

--- a/documentation/1.11/content/userguide/tools/inspect-image.md
+++ b/documentation/1.11/content/userguide/tools/inspect-image.md
@@ -16,7 +16,7 @@ Usage: imagetool inspect [OPTIONS]
 | Parameter | Definition | Default |
 | --- | --- | --- |
 | `--image`, `-i` | (Required) The image ID or image name to be inspected.  |   |
-| `--builder`, `-b` | Executable to inspect docker images. Use the full path of the executable if not on your path. | Defaults to 'docker', or, when set, to the value in environment variable WLSIMG_BUILDER. |
+| `--builder`, `-b` | Executable to inspect Docker images. Use the full path of the executable if not on your path. | Defaults to `docker`, or, when set, to the value in environment variable `WLSIMG_BUILDER`. |
 | `--format` | The output format. Supported values: `JSON` | `JSON`  |
 | `--patches` | Include OPatch information in the output, including a list of WebLogic patches that are applied.  |   |
 

--- a/documentation/1.11/content/userguide/tools/rebase-image.md
+++ b/documentation/1.11/content/userguide/tools/rebase-image.md
@@ -21,7 +21,7 @@ Usage: imagetool rebase [OPTIONS]
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0`  |   |
 | `--additionalBuildCommands` | Path to a file with additional build commands. For more details, see [Additional information](#--additionalbuildcommands). |
 | `--additionalBuildFiles` | Additional files that are required by your `additionalBuildCommands`.  A comma separated list of files that should be copied to the build context. See [Additional information](#--additionalbuildfiles). |
-| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path. | `docker`  |
+| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path. | Defaults to 'docker', or, when set, to the value in environment variable WLSIMG_BUILDER. |
 | `--buildNetwork` | Networking mode for the RUN instructions during the image build.  See `--network` for Docker `build`.  |   |
 | `--chown` | `userid:groupid` for JDK/Middleware installs and patches.  | `oracle:oracle` |
 | `--dryRun` | Skip Docker build execution and print the Dockerfile to stdout.  |  |

--- a/documentation/1.11/content/userguide/tools/rebase-image.md
+++ b/documentation/1.11/content/userguide/tools/rebase-image.md
@@ -21,7 +21,7 @@ Usage: imagetool rebase [OPTIONS]
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0`  |   |
 | `--additionalBuildCommands` | Path to a file with additional build commands. For more details, see [Additional information](#--additionalbuildcommands). |
 | `--additionalBuildFiles` | Additional files that are required by your `additionalBuildCommands`.  A comma separated list of files that should be copied to the build context. See [Additional information](#--additionalbuildfiles). |
-| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path. | Defaults to 'docker', or, when set, to the value in environment variable WLSIMG_BUILDER. |
+| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path. | Defaults to `docker`, or, when set, to the value in environment variable `WLSIMG_BUILDER`. |
 | `--buildNetwork` | Networking mode for the RUN instructions during the image build.  See `--network` for Docker `build`.  |   |
 | `--chown` | `userid:groupid` for JDK/Middleware installs and patches.  | `oracle:oracle` |
 | `--dryRun` | Skip Docker build execution and print the Dockerfile to stdout.  |  |

--- a/documentation/1.11/content/userguide/tools/update-image.md
+++ b/documentation/1.11/content/userguide/tools/update-image.md
@@ -29,7 +29,7 @@ Update WebLogic Docker image with selected patches
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0` |  |
 | `--additionalBuildCommands` | Path to a file with additional build commands. For more details, see [Additional information](#--additionalbuildcommands). | |
 | `--additionalBuildFiles` | Additional files that are required by your `additionalBuildCommands`.  A comma separated list of files that should be copied to the build context. See [Additional information](#--additionalbuildfiles). |  |
-| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path. | Defaults to 'docker', or, when set, to the value in environment variable WLSIMG_BUILDER. |
+| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path. | Defaults to `docker`, or, when set, to the value in environment variable `WLSIMG_BUILDER`. |
 | `--buildNetwork` | Networking mode for the RUN instructions during the image build.  See `--network` for Docker `build`. | |
 | `--chown` | `userid:groupid` for middleware patches and other operations. | Owner:Group of the Oracle Home |
 | `--dryRun` | Skip Docker build execution and print the Dockerfile to stdout. | |

--- a/documentation/1.11/content/userguide/tools/update-image.md
+++ b/documentation/1.11/content/userguide/tools/update-image.md
@@ -29,7 +29,7 @@ Update WebLogic Docker image with selected patches
 | `--tag` | (Required) Tag for the final build image. Example: `store/oracle/weblogic:12.2.1.3.0` |  |
 | `--additionalBuildCommands` | Path to a file with additional build commands. For more details, see [Additional information](#--additionalbuildcommands). | |
 | `--additionalBuildFiles` | Additional files that are required by your `additionalBuildCommands`.  A comma separated list of files that should be copied to the build context. See [Additional information](#--additionalbuildfiles). |  |
-| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path. | `docker` |
+| `--builder`, `-b` | Executable to process the Dockerfile. Use the full path of the executable if not on your path. | Defaults to 'docker', or, when set, to the value in environment variable WLSIMG_BUILDER. |
 | `--buildNetwork` | Networking mode for the RUN instructions during the image build.  See `--network` for Docker `build`. | |
 | `--chown` | `userid:groupid` for middleware patches and other operations. | Owner:Group of the Oracle Home |
 | `--dryRun` | Skip Docker build execution and print the Dockerfile to stdout. | |

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -374,9 +374,11 @@ public abstract class CommonOptions {
 
     @Option(
         names = {"--builder", "-b"},
-        description = "Executable to process the Dockerfile. Default: ${DEFAULT-VALUE}."
+        description = "Executable to process the Dockerfile."
+            + " Use the full path of the executable if not on your path."
+            + " Defaults to 'docker', or, when set, to the value in environment variable WLSIMG_BUILDER."
     )
-    String buildEngine = "docker";
+    String buildEngine = Constants.BUILDER_DEFAULT;
 
     @Option(
         names = {"--target"},

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/InspectImage.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/InspectImage.java
@@ -11,6 +11,7 @@ import java.util.concurrent.Callable;
 
 import com.oracle.weblogic.imagetool.api.model.CommandResponse;
 import com.oracle.weblogic.imagetool.inspect.InspectOutput;
+import com.oracle.weblogic.imagetool.util.Constants;
 import com.oracle.weblogic.imagetool.util.Utils;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -51,9 +52,11 @@ public class InspectImage implements Callable<CommandResponse> {
 
     @Option(
         names = {"--builder", "-b"},
-        description = "Executable to inspect docker images. Default: ${DEFAULT-VALUE}"
+        description = "Executable to inspect docker images."
+            + " Use the full path of the executable if not on your path."
+            + " Defaults to 'docker', or, when set, to the value in environment variable WLSIMG_BUILDER."
     )
-    String buildEngine = "docker";
+    String buildEngine = Constants.BUILDER_DEFAULT;
 
     @Option(
         names = {"--patches"},

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Constants.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/Constants.java
@@ -29,6 +29,7 @@ public final class Constants {
     public static final String BUSYBOX = "busybox";
     public static final List<String> BUSYBOX_OS_IDS = Collections.unmodifiableList(Arrays.asList("bb", "alpine"));
     public static final String ORACLE_LINUX = "ghcr.io/oracle/oraclelinux:8-slim";
+    public static final String BUILDER_DEFAULT = Utils.getEnvironmentProperty("WLSIMG_BUILDER", "docker");
 
     private Constants() {
         //restrict access


### PR DESCRIPTION
…as the build engine (if set). Continue to use 'docker' otherwise.