### PR TITLE
code around ARU changes in bugs that are cancelled

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruPatch.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruPatch.java
@@ -199,7 +199,7 @@ public class AruPatch implements Comparable<AruPatch> {
                 int index = patch.downloadPath().indexOf("patch_file=");
                 if (index < 0) {
                     logger.fine("Unusable patch data from ARU for id:" + patch.patchId()
-                        + "  ver:" + patch.version()+ "  url:" + patch.downloadUrl());
+                        + "  ver:" + patch.version() + "  url:" + patch.downloadUrl());
                 } else {
                     patch.fileName(patch.downloadPath().substring(index + "patch_file=".length()));
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruPatch.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruPatch.java
@@ -199,7 +199,7 @@ public class AruPatch implements Comparable<AruPatch> {
                 int index = patch.downloadPath().indexOf("patch_file=");
                 if (index < 0) {
                     logger.fine("Unusable patch data from ARU for id:" + patch.patchId()
-                        + "  ver:" + patch.version());
+                        + "  ver:" + patch.version()+ "  url:" + patch.downloadUrl());
                 } else {
                     patch.fileName(patch.downloadPath().substring(index + "patch_file=".length()));
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruPatch.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruPatch.java
@@ -198,19 +198,21 @@ public class AruPatch implements Comparable<AruPatch> {
 
                 int index = patch.downloadPath().indexOf("patch_file=");
                 if (index < 0) {
-                    throw new XPathExpressionException(Utils.getMessage("IMG-0059", patch.patchId()));
-                }
-                patch.fileName(patch.downloadPath().substring(index + "patch_file=".length()));
+                    logger.fine("Unusable patch data from ARU for id:" + patch.patchId()
+                        + "  ver:" + patch.version());
+                } else {
+                    patch.fileName(patch.downloadPath().substring(index + "patch_file=".length()));
 
-                logger.fine("AruPatch created id:" + patch.patchId()
-                    + "  ver:" + patch.version()
-                    + "  desc:" + patch.description()
-                    + "  rel:" + patch.release()
-                    + "  product:" + patch.product()
-                    + "  relName:" + patch.releaseName()
-                    + "  psu:" + patch.psuBundle()
-                    + "  url:" + patch.downloadUrl());
-                result.add(patch);
+                    logger.fine("AruPatch created id:" + patch.patchId()
+                        + "  ver:" + patch.version()
+                        + "  desc:" + patch.description()
+                        + "  rel:" + patch.release()
+                        + "  product:" + patch.product()
+                        + "  relName:" + patch.releaseName()
+                        + "  psu:" + patch.psuBundle()
+                        + "  url:" + patch.downloadUrl());
+                    result.add(patch);
+                }
             }
         }
         return result;


### PR DESCRIPTION
Code around ARU changes in bugs that are cancelled, where the download URL is deleted from metadata.  Bug 29135930 has this issue as of today.