### PR TITLE
Add support for the Oracle HTTP Server installer

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruProduct.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruProduct.java
@@ -18,6 +18,7 @@ public enum AruProduct {
     MFT("27538", "Oracle Managed File Transfer"),
     IDM("18391", "Oracle Identity Manager"),
     OAM("18388", "Oracle Access Manager"),
+    OHS("10300", "Oracle HTTP Server"),
     OUD("19748", "Oracle Unified Directory"),
     OID("10040", "Oracle Internet Directory"),
     WCC("13946", "Oracle WebCenter Content"),

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/DefaultResponseFile.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/DefaultResponseFile.java
@@ -28,6 +28,7 @@ public class DefaultResponseFile implements ResponseFile {
         "Collocated Oracle Identity and Access Manager (Managed through WebLogic server)";
     private static final String R_OAM =
         "Collocated Oracle Identity and Access Manager (Managed through WebLogic server)";
+    private static final String R_OHS = "Standalone HTTP Server (Managed independently of WebLogic server)";
     private static final String R_OUD = "Installation for Oracle Unified Directory";
     private static final String R_OID = "Collocated Oracle Internet Directory Server (Managed through WebLogic server)";
     private static final String R_WCC = "WebCenter Content";
@@ -74,6 +75,9 @@ public class DefaultResponseFile implements ResponseFile {
                 break;
             case OAM:
                 response = R_OAM;
+                break;
+            case OHS:
+                response = R_OHS;
                 break;
             case OUD:
                 response = R_OUD;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/FmwInstallerType.java
@@ -78,7 +78,9 @@ public enum FmwInstallerType {
         InstallerType.FMW, InstallerType.WCP),
     // Oracle WebCenter Sites
     WCS(Utils.toSet(FMW.products, AruProduct.WCS),
-        InstallerType.FMW, InstallerType.WCS)
+        InstallerType.FMW, InstallerType.WCS),
+    OHS(Collections.singleton(AruProduct.OHS),
+        InstallerType.OHS)
     ;
 
     private final InstallerType[] installers;

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/InstallerType.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/installer/InstallerType.java
@@ -19,6 +19,7 @@ public enum InstallerType {
     MFT("mft"),
     IDM("idm"),
     OAM("oam"),
+    OHS("ohs"),
     OUD("oud"),
     OID("oid"),
     WCC("wcc"),
@@ -27,7 +28,7 @@ public enum InstallerType {
     JDK("jdk"),
     WDT("wdt");
 
-    private String value;
+    private final String value;
 
     /**
      * Create an Enum value for the installer type.


### PR DESCRIPTION
The `--type` option will accept "ohs" as an option.  Using the 12.2.1.3 and 12.2.1.4 GA installers for OHS, the Image Tool will be able to create images with the latest PSUs for Oracle HTTP Server.