### PR TITLE
Add libnsl to images created with FMW type installers to support ADR on OL slim images

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonCreateOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonCreateOptions.java
@@ -44,6 +44,7 @@ public class CommonCreateOptions extends CommonPatchingOptions {
                 new MiddlewareInstall(getInstallerType(), installerVersion, installerResponseFiles);
             install.copyFiles(cache(), buildDir());
             dockerfileOptions.setMiddlewareInstall(install);
+            dockerfileOptions.mwOsPackages(install.getRequiredPackages());
         } else {
             dockerfileOptions.setWdtBase("os_update");
         }

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
@@ -66,6 +66,7 @@ public class DockerfileOptions {
     private MiddlewareInstall mwInstallers;
     private boolean domainGroupAsUser;
     private boolean usingBusybox;
+    private List<String> mwOsPackages;
 
     // WDT values
     private String wdtHome;
@@ -106,6 +107,7 @@ public class DockerfileOptions {
         username = "oracle";
         groupname = "oracle";
         tempDirectory = "/tmp/imagetool";
+        mwOsPackages = Collections.emptyList();
 
         // WDT values
         useWdt = false;
@@ -1113,5 +1115,13 @@ public class DockerfileOptions {
     public DockerfileOptions usingBusybox(boolean value) {
         usingBusybox = value;
         return this;
+    }
+
+    public List<String> mwOsPackages() {
+        return mwOsPackages;
+    }
+
+    public void mwOsPackages(List<String> value) {
+        mwOsPackages = value;
     }
 }

--- a/imagetool/src/main/resources/docker-files/package-managers.mustache
+++ b/imagetool/src/main/resources/docker-files/package-managers.mustache
@@ -6,25 +6,25 @@
 # Ensure necessary OS packages are installed
 {{#useYum}}
     RUN yum -y update \
-    && yum -y --downloaddir={{{tempDir}}} install gzip tar unzip libaio jq findutils diffutils {{#osPackages}}{{{.}}} {{/osPackages}}\
+    && yum -y --downloaddir={{{tempDir}}} install gzip tar unzip jq findutils diffutils {{#mwOsPackages}}{{{.}}} {{/mwOsPackages}}{{#osPackages}}{{{.}}} {{/osPackages}}\
     && yum -y --downloaddir={{{tempDir}}} clean all \
     && rm -rf /var/cache/yum/* \
     && rm -rf {{{tempDir}}}
 {{/useYum}}
 {{#useDnf}}
     RUN dnf -y update \
-    && dnf -y install gzip tar unzip libaio jq findutils diffutils {{#osPackages}}{{{.}}} {{/osPackages}}\
+    && dnf -y install gzip tar unzip jq findutils diffutils {{#mwOsPackages}}{{{.}}} {{/mwOsPackages}}{{#osPackages}}{{{.}}} {{/osPackages}}\
     && dnf clean all
 {{/useDnf}}
 {{#useMicroDnf}}
     RUN microdnf update \
-    && microdnf install gzip tar unzip libaio jq findutils diffutils shadow-utils {{#osPackages}}{{{.}}} {{/osPackages}}\
+    && microdnf install gzip tar unzip jq findutils diffutils shadow-utils {{#mwOsPackages}}{{{.}}} {{/mwOsPackages}}{{#osPackages}}{{{.}}} {{/osPackages}}\
     && microdnf clean all
 {{/useMicroDnf}}
 {{#useAptGet}}
     RUN apt-get -y update \
     && apt-get -y upgrade \
-    && apt-get -y install gzip tar unzip libaio jq findutils diffutils {{#osPackages}}{{{.}}} {{/osPackages}}\
+    && apt-get -y install gzip tar unzip jq findutils diffutils {{#mwOsPackages}}{{{.}}} {{/mwOsPackages}}{{#osPackages}}{{{.}}} {{/osPackages}}\
     && apt-get -y clean all
 {{/useAptGet}}
 {{#useApk}}

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/installer/InstallerTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/installer/InstallerTest.java
@@ -3,7 +3,9 @@
 
 package com.oracle.weblogic.imagetool.installer;
 
+import java.io.FileNotFoundException;
 import java.util.Arrays;
+import java.util.List;
 
 import com.oracle.weblogic.imagetool.aru.AruProduct;
 import com.oracle.weblogic.imagetool.util.Utils;
@@ -12,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("unit")
 class InstallerTest {
@@ -58,6 +61,22 @@ class InstallerTest {
         assertEquals(FmwInstallerType.FMW, FmwInstallerType.fromProductList(FMW_PRODUCTS + ",OIM"));
         assertNull(FmwInstallerType.fromProductList(""));
         assertNull(FmwInstallerType.fromProductList(null));
+    }
+
+    @Test
+    void mwInstallerOsPackagesFmw() throws FileNotFoundException {
+        MiddlewareInstall mw = new MiddlewareInstall(FmwInstallerType.SOA, "12.2.1.4.0", null);
+        List<String> response = mw.getRequiredPackages();
+        assertEquals(2, response.size());
+        assertTrue(response.contains("libaio"));
+        assertTrue(response.contains("libnsl"));
+    }
+
+    @Test
+    void mwInstallerOsPackages() throws FileNotFoundException {
+        MiddlewareInstall mw = new MiddlewareInstall(FmwInstallerType.WLS, "12.2.1.4.0", null);
+        List<String> response = mw.getRequiredPackages();
+        assertEquals(0, response.size());
     }
 }
 


### PR DESCRIPTION
Oracle Linux 8-slim removed libnsl from its distribution.  ADR, installed with WLS infrastructure installers, requires libnsl to run `adrci`.  This is the same problem found with libaio two years ago.  This change allows Middleware installers to be decorated with additional OS packages that need to be installed.