### PR TITLE
Only validate user credentials if there are patches involved.

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonPatchingOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonPatchingOptions.java
@@ -57,12 +57,14 @@ public abstract class CommonPatchingOptions extends CommonOptions {
         super.initializeOptions();
         password = Utils.getPasswordFromInputs(passwordStr, passwordFile, passwordEnv);
 
-        // if userid or password is provided, validate the pair of provided values
-        if ((userId != null || password != null) && !AruUtil.rest().checkCredentials(userId, password)) {
-            throw new InvalidCredentialException();
-        }
+        if (applyingPatches()) {
+            // if userid or password is provided, validate the pair of provided values
+            if ((userId != null || password != null) && !AruUtil.rest().checkCredentials(userId, password)) {
+                throw new InvalidCredentialException();
+            }
 
-        Utils.validatePatchIds(patches, false);
+            Utils.validatePatchIds(patches, false);
+        }
     }
 
     /**

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/cli/menu/CommonPatchingOptions2Test.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/cli/menu/CommonPatchingOptions2Test.java
@@ -37,7 +37,7 @@ class CommonPatchingOptions2Test {
     void noPassword() {
         // This test requires that ARUUtil instance NOT be overridden
         CreateImage createImage = new CreateImage();
-        new CommandLine(createImage).parseArgs("--tag", "tag:1", "--user", "derek");
+        new CommandLine(createImage).parseArgs("--tag", "tag:1", "--user", "derek", "--patches", "12345678");
         assertThrows(InvalidCredentialException.class, createImage::initializeOptions);
     }
 


### PR DESCRIPTION
There is no need to validate user credentials when no patching operations are going to be performed.  If the user provides `--user` but does NOT provide `--patches` or `--latestPSU` or `--recommendedPatches`, there is no need to validate the user credential.