### PR TITLE
Compare ARU product version numerically

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruPatch.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/AruPatch.java
@@ -25,7 +25,7 @@ public class AruPatch implements Comparable<AruPatch> {
     private static final LoggingFacade logger = LoggingFactory.getLogger(AruPatch.class);
 
     private String patchId;
-    private String version;
+    private Version version;
     private String description;
     private String product;
     private String release;
@@ -45,12 +45,20 @@ public class AruPatch implements Comparable<AruPatch> {
         return this;
     }
 
+    /**
+     * The ARU version number of the FMW product associated with this patch.
+     * @return The string value of the version found in ARU.
+     */
     public String version() {
-        return version;
+        if (version != null) {
+            return version.toString();
+        } else {
+            return null;
+        }
     }
 
     public AruPatch version(String value) {
-        version = value;
+        version = new Version(value);
         return this;
     }
 

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/Version.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/aru/Version.java
@@ -1,0 +1,91 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.weblogic.imagetool.aru;
+
+import java.util.Arrays;
+
+public class Version implements Comparable<Version> {
+    private final int[] sequence;
+    private final String stringValue;
+
+    /**
+     * Representation of the ARU version number used for Oracle products.
+     * Version must be one or more integers separated by a period, ".".
+     * @param value String to be parsed as the ARU version.
+     */
+    public Version(String value) {
+        stringValue = value;
+
+        if (value != null && !value.isEmpty()) {
+            // split version into a sequence tokens using the period separator
+            sequence = Arrays.stream(value.split("\\."))
+                .mapToInt(Integer::parseInt)
+                .toArray();
+        } else {
+            sequence = new int[1];
+        }
+    }
+
+    /**
+     * Return the sequence of version tokens padded to the minimum length with 0's.
+     * The sequence will NOT be truncated.
+     * @param minLength minimum number of version tokens in the array.
+     * @return sequence of version tokens
+     */
+    public int[] getSequence(int minLength) {
+        if (sequence.length < minLength) {
+            return Arrays.copyOf(sequence, minLength);
+        }
+        return sequence;
+    }
+
+    /**
+     * Compare this version number against the provided version, returning -1, 0, or 1 if
+     * this version is less than, equal to, or greater than the provided version, respectively.
+     * @param provided the object to be compared.
+     * @return -1, 0, or 1 if this version is less than, equal to, or greater than the provided version
+     */
+    @Override
+    public int compareTo(Version provided) {
+        int match = 0;
+        int sequenceLength = Math.max(sequence.length, provided.sequence.length);
+        int[] mySequence = getSequence(sequenceLength);
+        int[] providedSequence = provided.getSequence(sequenceLength);
+
+        for (int i = 0; i < sequenceLength; i++) {
+            if (mySequence[i] > providedSequence[i]) {
+                match = 1;
+            } else if (mySequence[i] < providedSequence[i]) {
+                match = -1;
+            }
+            if (match != 0) {
+                break;
+            }
+        }
+
+        return match;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Version version = (Version) o;
+        return this.compareTo(version) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(sequence);
+    }
+
+    @Override
+    public String toString() {
+        return stringValue;
+    }
+}

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -245,7 +245,9 @@ public abstract class CommonOptions {
             return;
         }
         Utils.deleteFilesRecursively(buildDir());
-        Utils.removeIntermediateDockerImages(buildEngine, buildId());
+        if (!dryRun) {
+            Utils.removeIntermediateDockerImages(buildEngine, buildId());
+        }
     }
 
     /**

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/aru/VersionTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/aru/VersionTest.java
@@ -1,0 +1,79 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package com.oracle.weblogic.imagetool.aru;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Tag("unit")
+class VersionTest {
+    @Test
+    void sameVersionNumber() {
+        Version a = new Version("1.2.3");
+        Version b = new Version("1.2.3");
+        assertEquals(0, b.compareTo(a));
+        assertEquals(0, a.compareTo(b));
+    }
+
+    @Test
+    void differentVersionNumbers() {
+        Version a = new Version("1.2.3");
+        Version b = new Version("1.2.4");
+        assertEquals(1, b.compareTo(a));
+        assertEquals(-1, a.compareTo(b));
+    }
+
+    @Test
+    void differentVersionLengths() {
+        Version a = new Version("1.2.3");
+        Version b = new Version("1.2.3.1");
+        assertEquals(1, b.compareTo(a));
+        assertEquals(-1, a.compareTo(b));
+    }
+
+    @Test
+    void integerComparison() {
+        Version a = new Version("13.9.4.2.9");
+        Version b = new Version("13.9.4.2.10");
+        assertEquals(1, b.compareTo(a));
+        assertEquals(-1, a.compareTo(b));
+    }
+
+    @Test
+    void nonNumericVersion() {
+        assertThrows(NumberFormatException.class, () -> new Version("1.A.4"));
+        assertThrows(NumberFormatException.class, () -> new Version("1.2.3-SNAP"));
+    }
+
+    @Test
+    void allowsNull() {
+        Version a = new Version(null);
+        Version b = new Version("1.2.3");
+        assertEquals(1, b.compareTo(a));
+        assertEquals(-1, a.compareTo(b));
+    }
+
+    @Test
+    void equalObjects() {
+        Version a = new Version("1.2.3");
+        Version b = new Version("1.2.3");
+        Version c = a;
+        assertEquals(a, b);
+        assertEquals(b, a);
+        assertEquals(a, c);
+    }
+
+    @Test
+    void hashcodeTest() {
+        Version a = new Version("1.2.3");
+        Version b = new Version("1.2.3");
+        Version c = new Version("1.2.4");
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a.hashCode(), c.hashCode());
+    }
+}

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/aru/VersionTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/aru/VersionTest.java
@@ -62,10 +62,9 @@ class VersionTest {
     void equalObjects() {
         Version a = new Version("1.2.3");
         Version b = new Version("1.2.3");
-        Version c = a;
         assertEquals(a, b);
         assertEquals(b, a);
-        assertEquals(a, c);
+        assertEquals(a, a);
     }
 
     @Test

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/aru/VersionTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/aru/VersionTest.java
@@ -43,6 +43,11 @@ class VersionTest {
     }
 
     @Test
+    void nullVersion() {
+        compareDifferingVersions(null, "1.2.3");
+    }
+
+    @Test
     void nonNumericVersion() {
         assertThrows(NumberFormatException.class, () -> new Version("1.A.4"));
         assertThrows(NumberFormatException.class, () -> new Version("1.2.3-SNAP"));
@@ -63,6 +68,7 @@ class VersionTest {
         assertEquals(a, b);
         assertEquals(b, a);
         assertEquals(a, a);
+        assertNotEquals(a, null);
     }
 
     @Test

--- a/imagetool/src/test/java/com/oracle/weblogic/imagetool/aru/VersionTest.java
+++ b/imagetool/src/test/java/com/oracle/weblogic/imagetool/aru/VersionTest.java
@@ -20,28 +20,26 @@ class VersionTest {
         assertEquals(0, a.compareTo(b));
     }
 
+    private void compareDifferingVersions(String firstVersion, String laterVersion) {
+        Version v1 = new Version(firstVersion);
+        Version v2 = new Version(laterVersion);
+        assertEquals(1, v2.compareTo(v1));
+        assertEquals(-1, v1.compareTo(v2));
+    }
+
     @Test
     void differentVersionNumbers() {
-        Version a = new Version("1.2.3");
-        Version b = new Version("1.2.4");
-        assertEquals(1, b.compareTo(a));
-        assertEquals(-1, a.compareTo(b));
+        compareDifferingVersions("1.2.3", "1.2.4");
     }
 
     @Test
     void differentVersionLengths() {
-        Version a = new Version("1.2.3");
-        Version b = new Version("1.2.3.1");
-        assertEquals(1, b.compareTo(a));
-        assertEquals(-1, a.compareTo(b));
+        compareDifferingVersions("1.2.3", "1.2.3.1");
     }
 
     @Test
     void integerComparison() {
-        Version a = new Version("13.9.4.2.9");
-        Version b = new Version("13.9.4.2.10");
-        assertEquals(1, b.compareTo(a));
-        assertEquals(-1, a.compareTo(b));
+        compareDifferingVersions("13.9.4.2.9", "13.9.4.2.10");
     }
 
     @Test


### PR DESCRIPTION
The ARU product version is being compared as string/text, which causes the sorting algorithm to fail for versions like 13.9.2.4.9 and 13.9.2.4.10.  This change is aware of semantic versions and compares the version strings as integers.