### PR TITLE
Updated microdnf command line for use with linux 9 which does not assume yes by default

### DIFF
--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/CommonOptions.java
@@ -223,6 +223,10 @@ public abstract class CommonOptions {
 
             PackageManagerType pkgMgr = PackageManagerType.valueOf(pkgMgrProp);
             logger.fine("fromImage package manager {0}", pkgMgr);
+            if (pkgMgr == PackageManagerType.MICRODNF && os.version() != null && os.version().startsWith("8")) {
+                logger.fine("Using older style format for microdnf for linux 8. ver={0}", os.version());
+                pkgMgr = PackageManagerType.MICRODNF_8;
+            }
             if (packageManager != PackageManagerType.OS_DEFAULT && pkgMgr != packageManager) {
                 // If the user is overriding the detected package manager, use the provided value
                 logger.info("IMG-0079", pkgMgr, packageManager);

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/PackageManagerType.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/cli/menu/PackageManagerType.java
@@ -9,6 +9,7 @@ public enum PackageManagerType {
     YUM,
     DNF,
     MICRODNF,
+    MICRODNF_8,
     APTGET,
     APK,
     ZYPPER

--- a/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
+++ b/imagetool/src/main/java/com/oracle/weblogic/imagetool/util/DockerfileOptions.java
@@ -299,7 +299,7 @@ public class DockerfileOptions {
                 pkgMgr = PackageManagerType.NONE;
             } else {
                 // This default must match the Package Manager for the configured fromImage default in baseImageName
-                pkgMgr = PackageManagerType.MICRODNF;
+                pkgMgr = PackageManagerType.MICRODNF_8;
             }
         } else {
             pkgMgr = option;
@@ -315,6 +315,11 @@ public class DockerfileOptions {
     @SuppressWarnings("unused")
     public boolean useMicroDnf() {
         return pkgMgr == PackageManagerType.MICRODNF;
+    }
+
+    @SuppressWarnings("unused")
+    public boolean useMicroDnf8() {
+        return pkgMgr == PackageManagerType.MICRODNF_8;
     }
 
     @SuppressWarnings("unused")

--- a/imagetool/src/main/resources/docker-files/package-managers.mustache
+++ b/imagetool/src/main/resources/docker-files/package-managers.mustache
@@ -17,10 +17,15 @@
     && dnf clean all
 {{/useDnf}}
 {{#useMicroDnf}}
+    RUN microdnf -y update \
+    && microdnf -y install gzip tar unzip libaio libnsl jq findutils diffutils shadow-utils {{#osPackages}}{{{.}}} {{/osPackages}}\
+    && microdnf clean all
+{{/useMicroDnf}}
+{{#useMicroDnf8}}
     RUN microdnf update \
     && microdnf install gzip tar unzip libaio libnsl jq findutils diffutils shadow-utils {{#osPackages}}{{{.}}} {{/osPackages}}\
     && microdnf clean all
-{{/useMicroDnf}}
+{{/useMicroDnf8}}
 {{#useAptGet}}
     RUN apt-get -y update \
     && apt-get -y upgrade \


### PR DESCRIPTION
Detect OL8 and do not specify the -y (assume yes) flag when using `microdnf`.  For OL9, `microdnf` must have the `-y`.